### PR TITLE
FCFB-75: link play list in message embed

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -516,6 +516,8 @@ class DiscordMessageHandler(
             }
         }
 
+        messageContent += "\n\n[Play List](http://51.81.32.234:462/game-details/${game.gameId})"
+
         val originalScorebug = scorebugClient.getScorebugByGameId(game.gameId)
 
         // If no scorebug was found, generate one and try to read it again


### PR DESCRIPTION
This pull request includes a small change to the `DiscordMessageHandler` class in the `DiscordMessageHandler.kt` file. The change appends a play list link to the `messageContent` variable.

* [`src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt`](diffhunk://#diff-568a86bf250710df5b654ac68ab48d77e650d338d6e0f018c6f951dadc74f8a3R519-R520): Added a play list link to the `messageContent` variable.