### PR TITLE
FCFB-28: Ping game players during announcement

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/MessageAllGamesCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/MessageAllGamesCommand.kt
@@ -14,7 +14,6 @@ import dev.kord.rest.builder.interaction.string
 
 class MessageAllGamesCommand(
     private val gameClient: GameClient,
-    private val textChannelThreadHandler: TextChannelThreadHandler,
     private val discordMessageHandler: DiscordMessageHandler,
 ) {
     suspend fun register(client: Kord) {
@@ -36,7 +35,7 @@ class MessageAllGamesCommand(
             "${interaction.user.username} is messaging all games",
         )
         val command = interaction.command
-        val messageContent = "**ANNOUNCEMENT**\n\n ${command.options["message"]!!.value}"
+        val messageContent = "**ANNOUNCEMENT**\n${command.options["message"]!!.value}"
         val response = interaction.deferPublicResponse()
 
         val gameList =
@@ -47,14 +46,7 @@ class MessageAllGamesCommand(
 
         try {
             for (game in gameList) {
-                val channel =
-                    textChannelThreadHandler.getTextChannelThreadById(
-                        interaction.kord,
-                        Snowflake(
-                            game.homePlatformId ?: game.awayPlatformId ?: throw Exception("No platform ID found for game ${game.gameId}"),
-                        ),
-                    )
-                discordMessageHandler.sendGeneralMessage(channel, messageContent)
+                discordMessageHandler.sendGameAnnouncement(interaction.kord, game, messageContent)
             }
             response.respond { this.content = "Message all games command successful!" }
         } catch (e: Exception) {

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/MessageAllGamesCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/MessageAllGamesCommand.kt
@@ -2,11 +2,9 @@ package com.fcfb.discord.refbot.commands
 
 import com.fcfb.discord.refbot.api.GameClient
 import com.fcfb.discord.refbot.handlers.discord.DiscordMessageHandler
-import com.fcfb.discord.refbot.handlers.discord.TextChannelThreadHandler
 import com.fcfb.discord.refbot.model.fcfb.game.Game
 import com.fcfb.discord.refbot.model.fcfb.game.TeamSide
 import com.fcfb.discord.refbot.utils.Logger
-import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.behavior.interaction.response.respond
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -50,7 +50,7 @@ class DiscordMessageHandler(
     suspend fun sendGameAnnouncement(
         client: Kord,
         game: Game,
-        messageContent: String
+        messageContent: String,
     ): Message? {
         val channel =
             textChannelThreadHandler.getTextChannelThreadById(

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -41,16 +41,33 @@ class DiscordMessageHandler(
     private val scorebugClient: ScorebugClient,
     private val gameUtils: GameUtils,
     private val fileHandler: FileHandler,
+    private val textChannelThreadHandler: TextChannelThreadHandler,
     private val properties: Properties,
 ) {
     /**
-     * Send a general message to a text channel
+     * Send an announcement to a game
      */
-    suspend fun sendGeneralMessage(
-        textChannel: TextChannelThread?,
-        messageContent: String,
+    suspend fun sendGameAnnouncement(
+        client: Kord,
+        game: Game,
+        messageContent: String
     ): Message? {
-        return sendMessageFromTextChannelObject(textChannel, messageContent, null)
+        val channel =
+            textChannelThreadHandler.getTextChannelThreadById(
+                client,
+                Snowflake(
+                    game.homePlatformId ?: game.awayPlatformId ?: throw Exception("No platform ID found for game ${game.gameId}"),
+                ),
+            )
+
+        // Append user pings
+        val homeCoaches = game.homeCoachDiscordIds.map { client.getUser(Snowflake(it)) }
+        val awayCoaches = game.awayCoachDiscordIds.map { client.getUser(Snowflake(it)) }
+        var updatedMessageContent = joinMentions(homeCoaches)
+        updatedMessageContent += joinMentions(awayCoaches)
+        updatedMessageContent += "\n\n" + messageContent
+
+        return sendMessageFromTextChannelObject(channel, updatedMessageContent, null)
     }
 
     /**

--- a/src/main/kotlin/com/fcfb/discord/refbot/koin/AppModule.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/koin/AppModule.kt
@@ -79,7 +79,7 @@ val appModule =
         single { GameInfoCommand(get()) }
         single { HireCoachCommand(get()) }
         single { HireInterimCoachCommand(get()) }
-        single { MessageAllGamesCommand(get(), get(), get()) }
+        single { MessageAllGamesCommand(get(), get()) }
         single { PingCommand(get(), get(), get()) }
         single { RegisterCommand(get()) }
         single { StartGameCommand(get()) }
@@ -94,5 +94,5 @@ val appModule =
             )
         }
         single { FCFBDiscordRefBot(get(), get(), get(), get()) }
-        single { DiscordMessageHandler(get(), get(), get(), get(), get(), get(), get()) }
+        single { DiscordMessageHandler(get(), get(), get(), get(), get(), get(), get(), get()) }
     }


### PR DESCRIPTION
This pull request includes several changes to the `MessageAllGamesCommand` and `DiscordMessageHandler` classes to improve the handling of game announcements. The most important changes include removing the dependency on `TextChannelThreadHandler` from `MessageAllGamesCommand`, updating the message content format, and enhancing the `sendGameAnnouncement` method to include user pings.

Changes to `MessageAllGamesCommand`:

* Removed the dependency on `TextChannelThreadHandler` from the constructor and updated the `AppModule` configuration accordingly. [[1]](diffhunk://#diff-ed2c5ca7a268f4ed9e0544a7d5ae962c3cfb0efbdb77fdeead83dbb7bb82038dL5-L17) [[2]](diffhunk://#diff-6999374f16a060f691754d7f4c6c5bba6e8136772c501c4e1fc068c2a14ca52aL82-R82)
* Modified the message content format by removing the extra newline after the announcement heading.
* Replaced the logic for sending messages to games by calling the new `sendGameAnnouncement` method in `DiscordMessageHandler`.

Changes to `DiscordMessageHandler`:

* Added a new dependency on `TextChannelThreadHandler` and updated the `AppModule` configuration accordingly. [[1]](diffhunk://#diff-568a86bf250710df5b654ac68ab48d77e650d338d6e0f018c6f951dadc74f8a3R44-R70) [[2]](diffhunk://#diff-6999374f16a060f691754d7f4c6c5bba6e8136772c501c4e1fc068c2a14ca52aL97-R97)
* Replaced the `sendGeneralMessage` method with `sendGameAnnouncement`, which retrieves the appropriate text channel and appends user pings before sending the message.