### PR TITLE
FCFB-34: Don't require number for spike and kneels

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/api/PlayClient.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/api/PlayClient.kt
@@ -82,19 +82,28 @@ class PlayClient {
     internal suspend fun submitOffensiveNumber(
         gameId: Int,
         offensiveSubmitter: String,
-        offensiveNumber: Int,
+        offensiveNumber: Int?,
         playCall: PlayCall,
         runoffType: RunoffType,
         offensiveTimeoutCalled: Boolean,
     ): Play? {
         val endpointUrl =
-            "$baseUrl/play/submit_offense?" +
-                "gameId=$gameId&" +
-                "offensiveSubmitter=$offensiveSubmitter&" +
-                "offensiveNumber=$offensiveNumber&" +
-                "playCall=$playCall&" +
-                "runoffType=$runoffType&" +
-                "timeoutCalled=$offensiveTimeoutCalled"
+            if (offensiveNumber == null) {
+                "$baseUrl/play/submit_offense?" +
+                    "gameId=$gameId&" +
+                    "offensiveSubmitter=$offensiveSubmitter&" +
+                    "playCall=$playCall&" +
+                    "runoffType=$runoffType&" +
+                    "timeoutCalled=$offensiveTimeoutCalled"
+            } else {
+                "$baseUrl/play/submit_offense?" +
+                    "gameId=$gameId&" +
+                    "offensiveSubmitter=$offensiveSubmitter&" +
+                    "offensiveNumber=$offensiveNumber&" +
+                    "playCall=$playCall&" +
+                    "runoffType=$runoffType&" +
+                    "timeoutCalled=$offensiveTimeoutCalled"
+            }
 
         return putRequest(endpointUrl)
     }

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/GameHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/GameHandler.kt
@@ -92,13 +92,17 @@ class GameHandler(
         game: Game,
         message: Message,
     ) {
-        val number =
-            when (val messageNumber = gameUtils.parseValidNumberFromMessage(message)) {
-                -1 -> return errorHandler.multipleNumbersFoundError(message)
-                -2 -> return errorHandler.invalidNumberError(message)
-                else -> messageNumber
-            }
         val playCall = gameUtils.parsePlayCallFromMessage(message) ?: return errorHandler.invalidPlayCall(message)
+        val number =
+            if (playCall == PlayCall.KNEEL || playCall == PlayCall.SPIKE) {
+                null
+            } else {
+                when (val messageNumber = gameUtils.parseValidNumberFromMessage(message)) {
+                    -1 -> return errorHandler.multipleNumbersFoundError(message)
+                    -2 -> return errorHandler.invalidNumberError(message)
+                    else -> messageNumber
+                }
+            }
         val runoffType = gameUtils.parseRunoffTypeFromMessage(game, message)
         val timeoutCalled = gameUtils.parseTimeoutFromMessage(message)
         val offensiveSubmitter = message.author?.username ?: return errorHandler.invalidOffensiveSubmitter(message)

--- a/src/main/kotlin/com/fcfb/discord/refbot/model/fcfb/game/Play.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/model/fcfb/game/Play.kt
@@ -23,7 +23,7 @@ data class Play(
     @JsonProperty("offensive_submitter") val offensiveSubmitter: String?,
     @JsonProperty("play_call") val playCall: PlayCall?,
     @JsonProperty("result") val result: Scenario?,
-    @JsonProperty("difference") val difference: Int,
+    @JsonProperty("difference") val difference: Int?,
     @JsonProperty("actual_result") val actualResult: ActualResult?,
     @JsonProperty("yards") val yards: Int,
     @JsonProperty("play_time") val playTime: Int,


### PR DESCRIPTION
This pull request introduces changes to handle cases where the offensive number may be null in the `submitOffensiveNumber` method, and updates related classes to accommodate this change. The most important changes include modifications to the `PlayClient`, `GameHandler`, and `Play` classes.

Handling null offensive numbers:

* [`src/main/kotlin/com/fcfb/discord/refbot/api/PlayClient.kt`](diffhunk://#diff-9a8d5975160c504e9dc54ae969abda7249ccc4d379b56119a9aa01bc1ee231cbL85-R106): Updated the `submitOffensiveNumber` method to handle cases where the offensive number is null by adjusting the endpoint URL accordingly.

Updates to related classes:

* [`src/main/kotlin/com/fcfb/discord/refbot/handlers/GameHandler.kt`](diffhunk://#diff-9d2112d8dfad83b05c05c9bf3e33df2d6d3d46984e7cded414902b166cfddc94R95-R105): Modified the logic in the `GameHandler` class to set the offensive number to null for specific play calls (KNEEL or SPIKE) and to handle errors more effectively.
* [`src/main/kotlin/com/fcfb/discord/refbot/model/fcfb/game/Play.kt`](diffhunk://#diff-4d3338aa2c9cbed65fae840669af48d147dd611ab1438562aa81424c7f53d877L26-R26): Changed the `difference` property in the `Play` data class to be nullable to reflect the possibility of a null offensive number.