### PR TITLE
FCFB-39: Add logging for play messages

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/api/LogClient.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/api/LogClient.kt
@@ -1,0 +1,88 @@
+package com.fcfb.discord.refbot.api
+
+import com.fcfb.discord.refbot.config.JacksonConfig
+import com.fcfb.discord.refbot.model.log.MessageType
+import com.fcfb.discord.refbot.model.log.RequestMessageLog
+import com.fcfb.discord.refbot.utils.Logger
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.engine.cio.endpoint
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import java.util.Properties
+
+class LogClient {
+    private val baseUrl: String
+    private val httpClient =
+        HttpClient(CIO) {
+            engine {
+                maxConnectionsCount = 64
+                endpoint {
+                    maxConnectionsPerRoute = 8
+                    connectTimeout = 10_000
+                    requestTimeout = 60_000
+                }
+            }
+        }
+
+    init {
+        val stream =
+            this::class.java.classLoader.getResourceAsStream("application.properties")
+                ?: throw RuntimeException("application.properties file not found")
+        val properties = Properties()
+        properties.load(stream)
+        baseUrl = properties.getProperty("api.url")
+    }
+
+    /**
+     * Get the current play in Arceus
+     * @param gameId
+     */
+    internal suspend fun logRequestMessage(
+        gameId: Int,
+        playId: Int?,
+        messageId: ULong,
+        messageContent: String,
+        messageLocation: String?,
+        messageType: MessageType,
+    ): RequestMessageLog? {
+        val body =
+            RequestMessageLog(
+                messageType = messageType,
+                gameId = gameId,
+                playId = playId,
+                messageId = messageId.toInt(),
+                messageContent = messageContent,
+                messageLocation = messageLocation,
+                messageTs = System.currentTimeMillis().toString(),
+            )
+        val endpointUrl = "$baseUrl/request_message_log"
+        return postRequestWithBody(endpointUrl, body)
+    }
+
+    private suspend fun postRequestWithBody(
+        endpointUrl: String,
+        body: Any,
+    ): RequestMessageLog? {
+        return try {
+            val response: HttpResponse =
+                httpClient.post(endpointUrl) {
+                    contentType(ContentType.Application.Json)
+                    setBody(body)
+                }
+            val jsonResponse = response.bodyAsText()
+            val objectMapper = JacksonConfig().configureGameMapping()
+            objectMapper.readValue(jsonResponse, RequestMessageLog::class.java)
+        } catch (e: Exception) {
+            Logger.error(
+                e.message
+                    ?: "Unknown error occurred while making a post request to the request message log endpoint",
+            )
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/fcfb/discord/refbot/config/JacksonConfig.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/config/JacksonConfig.kt
@@ -11,6 +11,7 @@ import com.fcfb.discord.refbot.config.deserializers.DefensivePlaybookDeserialize
 import com.fcfb.discord.refbot.config.deserializers.GameModeDeserializer
 import com.fcfb.discord.refbot.config.deserializers.GameStatusDeserializer
 import com.fcfb.discord.refbot.config.deserializers.GameTypeDeserializer
+import com.fcfb.discord.refbot.config.deserializers.MessageTypeDeserializer
 import com.fcfb.discord.refbot.config.deserializers.OffensivePlaybookDeserializer
 import com.fcfb.discord.refbot.config.deserializers.PlatformDeserializer
 import com.fcfb.discord.refbot.config.deserializers.PlayCallDeserializer
@@ -38,6 +39,7 @@ import com.fcfb.discord.refbot.model.fcfb.game.Scenario
 import com.fcfb.discord.refbot.model.fcfb.game.Subdivision
 import com.fcfb.discord.refbot.model.fcfb.game.TVChannel
 import com.fcfb.discord.refbot.model.fcfb.game.TeamSide
+import com.fcfb.discord.refbot.model.log.MessageType
 
 class JacksonConfig {
     private fun customGameModule(): SimpleModule {
@@ -70,7 +72,7 @@ class JacksonConfig {
         }
     }
 
-    fun customFCFBUserModule(): SimpleModule {
+    private fun customFCFBUserModule(): SimpleModule {
         return SimpleModule().apply {
             addDeserializer(CoachPosition::class.java, CoachPositionDeserializer())
             addDeserializer(Role::class.java, RoleDeserializer())
@@ -85,7 +87,7 @@ class JacksonConfig {
         }
     }
 
-    fun customTeamModule(): SimpleModule {
+    private fun customTeamModule(): SimpleModule {
         return SimpleModule().apply {
             addDeserializer(Conference::class.java, ConferenceDeserializer())
         }
@@ -96,6 +98,20 @@ class JacksonConfig {
             registerModule(KotlinModule.Builder().build())
             registerModule(customTeamModule())
             propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
+        }
+    }
+
+    fun configureRequestMessageLogMapping(): ObjectMapper {
+        return ObjectMapper().apply {
+            registerModule(KotlinModule.Builder().build())
+            registerModule(customRequestMessageLogModule())
+            propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
+        }
+    }
+
+    private fun customRequestMessageLogModule(): SimpleModule {
+        return SimpleModule().apply {
+            addDeserializer(MessageType::class.java, MessageTypeDeserializer())
         }
     }
 }

--- a/src/main/kotlin/com/fcfb/discord/refbot/config/deserializers/MessageTypeDeserializer.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/config/deserializers/MessageTypeDeserializer.kt
@@ -1,0 +1,17 @@
+package com.fcfb.discord.refbot.config.deserializers
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fcfb.discord.refbot.model.log.MessageType
+
+class MessageTypeDeserializer : JsonDeserializer<MessageType>() {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext,
+    ): MessageType {
+        val value = parser.text.uppercase()
+        return MessageType.entries.find { it.name == value }
+            ?: throw IllegalArgumentException("Invalid  essage Type value: $value")
+    }
+}

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/GameHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/GameHandler.kt
@@ -79,6 +79,7 @@ class GameHandler(
             discordMessageHandler.sendRequestForOffensiveNumber(
                 client,
                 game,
+                currentPlay,
                 false,
                 message,
             )
@@ -185,12 +186,12 @@ class GameHandler(
         val timeoutCalled = gameUtils.parseTimeoutFromMessage(message)
         val defensiveSubmitter = message.author?.username ?: return errorHandler.invalidDefensiveSubmitter(message)
 
-        // Submit the defensive number and get the play outcome
-        playClient.submitDefensiveNumber(game.gameId, defensiveSubmitter, number, timeoutCalled)
-            ?: return errorHandler.invalidDefensiveNumberSubmission(message)
+        val play =
+            playClient.submitDefensiveNumber(game.gameId, defensiveSubmitter, number, timeoutCalled)
+                ?: return errorHandler.invalidDefensiveNumberSubmission(message)
 
         discordMessageHandler.sendNumberConfirmationMessage(game, number, timeoutCalled, message)
-        discordMessageHandler.sendRequestForOffensiveNumber(client, game, timeoutCalled, message)
+        discordMessageHandler.sendRequestForOffensiveNumber(client, game, play, timeoutCalled, message)
     }
 
     /**

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -2,6 +2,7 @@ package com.fcfb.discord.refbot.handlers.discord
 
 import com.fcfb.discord.refbot.api.GameClient
 import com.fcfb.discord.refbot.api.GameWriteupClient
+import com.fcfb.discord.refbot.api.LogClient
 import com.fcfb.discord.refbot.api.ScorebugClient
 import com.fcfb.discord.refbot.handlers.FileHandler
 import com.fcfb.discord.refbot.model.discord.MessageConstants.Error
@@ -16,6 +17,7 @@ import com.fcfb.discord.refbot.model.fcfb.game.PlayCall
 import com.fcfb.discord.refbot.model.fcfb.game.PlayType
 import com.fcfb.discord.refbot.model.fcfb.game.Scenario
 import com.fcfb.discord.refbot.model.fcfb.game.TeamSide
+import com.fcfb.discord.refbot.model.log.MessageType
 import com.fcfb.discord.refbot.utils.GameUtils
 import com.fcfb.discord.refbot.utils.Logger
 import com.fcfb.discord.refbot.utils.Properties
@@ -39,6 +41,7 @@ class DiscordMessageHandler(
     private val gameClient: GameClient,
     private val gameWriteupClient: GameWriteupClient,
     private val scorebugClient: ScorebugClient,
+    private val logClient: LogClient,
     private val gameUtils: GameUtils,
     private val fileHandler: FileHandler,
     private val textChannelThreadHandler: TextChannelThreadHandler,
@@ -157,10 +160,20 @@ class DiscordMessageHandler(
             }
         val (messageContent, embedData) = gameMessage.first
         val defensiveCoaches = gameMessage.second
-        val numberRequestMessage = sendPrivateMessage(defensiveCoaches, embedData, messageContent, previousMessage)
         try {
+            val numberRequestMessage = sendPrivateMessage(defensiveCoaches, embedData, messageContent, previousMessage)
             gameClient.updateRequestMessageId(game.gameId, numberRequestMessage)
             gameClient.updateLastMessageTimestamp(game.gameId)
+            for (message in numberRequestMessage) {
+                logClient.logRequestMessage(
+                    MessageType.DEFENSE,
+                    game.gameId,
+                    play?.playId ?: 0,
+                    message?.id?.value,
+                    messageContent,
+                    defensiveCoaches.toString(),
+                )
+            }
             return true
         } catch (e: Exception) {
             sendErrorMessage(previousMessage ?: return false, Error.FAILED_TO_SEND_NUMBER_REQUEST_MESSAGE)
@@ -178,6 +191,7 @@ class DiscordMessageHandler(
     suspend fun sendRequestForOffensiveNumber(
         client: Kord,
         game: Game,
+        play: Play?,
         timeoutCalled: Boolean,
         previousMessage: Message? = null,
     ): Boolean {
@@ -208,6 +222,14 @@ class DiscordMessageHandler(
         try {
             gameClient.updateRequestMessageId(game.gameId, listOf(numberRequestMessage))
             gameClient.updateLastMessageTimestamp(game.gameId)
+            playClient.logOffensiveNumberRequest(
+                MessageType.OFFENSE,
+                game.gameId,
+                play?.playId ?: 0,
+                numberRequestMessage.id.value.toString(),
+                numberRequestMessage.content,
+                numberRequestMessage.getJumpUrl(),
+            )
             return true
         } catch (e: Exception) {
             sendErrorMessage(previousMessage ?: return false, Error.FAILED_TO_SEND_NUMBER_REQUEST_MESSAGE)

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -166,12 +166,11 @@ class DiscordMessageHandler(
             gameClient.updateLastMessageTimestamp(game.gameId)
             for (message in numberRequestMessage) {
                 logClient.logRequestMessage(
-                    MessageType.DEFENSE,
+                    MessageType.PRIVATE_MESSAGE,
                     game.gameId,
                     play?.playId ?: 0,
-                    message?.id?.value,
-                    messageContent,
-                    defensiveCoaches.toString(),
+                    message?.id?.value ?: 0.toULong(),
+                    defensiveCoaches.map { it?.username }.toString(),
                 )
             }
             return true
@@ -222,12 +221,11 @@ class DiscordMessageHandler(
         try {
             gameClient.updateRequestMessageId(game.gameId, listOf(numberRequestMessage))
             gameClient.updateLastMessageTimestamp(game.gameId)
-            playClient.logOffensiveNumberRequest(
-                MessageType.OFFENSE,
+            logClient.logRequestMessage(
+                MessageType.GAME_THREAD,
                 game.gameId,
                 play?.playId ?: 0,
-                numberRequestMessage.id.value.toString(),
-                numberRequestMessage.content,
+                numberRequestMessage.id.value,
                 numberRequestMessage.getJumpUrl(),
             )
             return true

--- a/src/main/kotlin/com/fcfb/discord/refbot/koin/AppModule.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/koin/AppModule.kt
@@ -4,6 +4,7 @@ import com.fcfb.discord.refbot.FCFBDiscordRefBot
 import com.fcfb.discord.refbot.api.AuthClient
 import com.fcfb.discord.refbot.api.GameClient
 import com.fcfb.discord.refbot.api.GameWriteupClient
+import com.fcfb.discord.refbot.api.LogClient
 import com.fcfb.discord.refbot.api.PlayClient
 import com.fcfb.discord.refbot.api.ScorebugClient
 import com.fcfb.discord.refbot.api.TeamClient
@@ -56,6 +57,7 @@ val appModule =
         single { GameClient() }
         single { GameWriteupClient() }
         single { PlayClient() }
+        single { LogClient() }
         single { ScorebugClient() }
         single { TeamClient() }
         single { UserClient() }
@@ -100,5 +102,5 @@ val appModule =
             )
         }
         single { FCFBDiscordRefBot(get(), get(), get(), get()) }
-        single { DiscordMessageHandler(get(), get(), get(), get(), get(), get(), get(), get()) }
+        single { DiscordMessageHandler(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     }

--- a/src/main/kotlin/com/fcfb/discord/refbot/model/log/RequestMessageLog.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/model/log/RequestMessageLog.kt
@@ -1,0 +1,21 @@
+package com.fcfb.discord.refbot.model.log
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class RequestMessageLog(
+    @JsonProperty("message_type") val messageType: MessageType,
+    @JsonProperty("game_id") val gameId: Int,
+    @JsonProperty("play_id") val playId: Int?,
+    @JsonProperty("message_id") val messageId: Int,
+    @JsonProperty("message_content") val messageContent: String,
+    @JsonProperty("message_location") val messageLocation: String?,
+    @JsonProperty("message_ts") val messageTs: String,
+)
+
+enum class MessageType(val description: String) {
+    OFFENSE("Offense"),
+    DEFENSE("Defense"),
+}

--- a/src/main/kotlin/com/fcfb/discord/refbot/model/log/RequestMessageLog.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/model/log/RequestMessageLog.kt
@@ -6,16 +6,16 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
 data class RequestMessageLog(
+    @JsonProperty("id") val id: Long? = 0,
     @JsonProperty("message_type") val messageType: MessageType,
     @JsonProperty("game_id") val gameId: Int,
     @JsonProperty("play_id") val playId: Int?,
-    @JsonProperty("message_id") val messageId: Int,
-    @JsonProperty("message_content") val messageContent: String,
+    @JsonProperty("message_id") val messageId: Long,
     @JsonProperty("message_location") val messageLocation: String?,
     @JsonProperty("message_ts") val messageTs: String,
 )
 
 enum class MessageType(val description: String) {
-    OFFENSE("Offense"),
-    DEFENSE("Defense"),
+    GAME_THREAD("Game Thread"),
+    PRIVATE_MESSAGE("Private Message"),
 }


### PR DESCRIPTION
This pull request introduces a new logging feature for message requests and includes several changes to the codebase to support this functionality. The most important changes involve the addition of the `LogClient` class, updates to the `JacksonConfig` class, and modifications to the `DiscordMessageHandler` class to integrate the new logging feature.

### New Logging Feature:

* [`src/main/kotlin/com/fcfb/discord/refbot/api/LogClient.kt`](diffhunk://#diff-c1c4107ea8591b00964a46016b787a6fb33a4dfd69413067001ccecc4a8410e7R1-R92): Added a new `LogClient` class to handle logging of message requests to an external API. This class includes methods for posting log data and configuring the HTTP client.
* [`src/main/kotlin/com/fcfb/discord/refbot/model/log/RequestMessageLog.kt`](diffhunk://#diff-e43b0ed0634fa2b3880d052190e9620661c1120f2818824e9ede8178d82e534cR1-R21): Added a new data class `RequestMessageLog` and an enum `MessageType` to represent the log structure and message types.

### Updates to Jackson Configuration:

* [`src/main/kotlin/com/fcfb/discord/refbot/config/JacksonConfig.kt`](diffhunk://#diff-1b4540a88de8ab93c641f434dc926f708779a14caf9a29c336d05ab19fdec57aR14): Added a new method `configureRequestMessageLogMapping` to configure the Jackson object mapper for `RequestMessageLog`. Also, added a new deserializer for `MessageType` and updated visibility of some methods to private. [[1]](diffhunk://#diff-1b4540a88de8ab93c641f434dc926f708779a14caf9a29c336d05ab19fdec57aR14) [[2]](diffhunk://#diff-1b4540a88de8ab93c641f434dc926f708779a14caf9a29c336d05ab19fdec57aR42) [[3]](diffhunk://#diff-1b4540a88de8ab93c641f434dc926f708779a14caf9a29c336d05ab19fdec57aL73-R75) [[4]](diffhunk://#diff-1b4540a88de8ab93c641f434dc926f708779a14caf9a29c336d05ab19fdec57aL88-R90) [[5]](diffhunk://#diff-1b4540a88de8ab93c641f434dc926f708779a14caf9a29c336d05ab19fdec57aR103-R116)
* [`src/main/kotlin/com/fcfb/discord/refbot/config/deserializers/MessageTypeDeserializer.kt`](diffhunk://#diff-aa16af10600d09aeebda87ed70f7568949df305d4836ef4aefdbbbc7ffa80e3eR1-R17): Added a new deserializer for `MessageType` to handle custom deserialization logic.

### Integration with Discord Message Handler:

* [`src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt`](diffhunk://#diff-568a86bf250710df5b654ac68ab48d77e650d338d6e0f018c6f951dadc74f8a3R5): Modified the `DiscordMessageHandler` class to include the `LogClient` and log message requests for both private messages and game thread messages. [[1]](diffhunk://#diff-568a86bf250710df5b654ac68ab48d77e650d338d6e0f018c6f951dadc74f8a3R5) [[2]](diffhunk://#diff-568a86bf250710df5b654ac68ab48d77e650d338d6e0f018c6f951dadc74f8a3R20) [[3]](diffhunk://#diff-568a86bf250710df5b654ac68ab48d77e650d338d6e0f018c6f951dadc74f8a3R44) [[4]](diffhunk://#diff-568a86bf250710df5b654ac68ab48d77e650d338d6e0f018c6f951dadc74f8a3L160-R175) [[5]](diffhunk://#diff-568a86bf250710df5b654ac68ab48d77e650d338d6e0f018c6f951dadc74f8a3R193) [[6]](diffhunk://#diff-568a86bf250710df5b654ac68ab48d77e650d338d6e0f018c6f951dadc74f8a3R224-R230)

### Miscellaneous Updates:

* [`src/main/kotlin/com/fcfb/discord/refbot/koin/AppModule.kt`](diffhunk://#diff-6999374f16a060f691754d7f4c6c5bba6e8136772c501c4e1fc068c2a14ca52aR7): Updated the dependency injection module to provide the `LogClient` and updated the `DiscordMessageHandler` to include the new dependency. [[1]](diffhunk://#diff-6999374f16a060f691754d7f4c6c5bba6e8136772c501c4e1fc068c2a14ca52aR7) [[2]](diffhunk://#diff-6999374f16a060f691754d7f4c6c5bba6e8136772c501c4e1fc068c2a14ca52aR60) [[3]](diffhunk://#diff-6999374f16a060f691754d7f4c6c5bba6e8136772c501c4e1fc068c2a14ca52aL103-R105)
* [`src/main/kotlin/com/fcfb/discord/refbot/handlers/GameHandler.kt`](diffhunk://#diff-9d2112d8dfad83b05c05c9bf3e33df2d6d3d46984e7cded414902b166cfddc94R82): Made minor adjustments to the `GameHandler` class to pass the current play to the `sendRequestForOffensiveNumber` method. [[1]](diffhunk://#diff-9d2112d8dfad83b05c05c9bf3e33df2d6d3d46984e7cded414902b166cfddc94R82) [[2]](diffhunk://#diff-9d2112d8dfad83b05c05c9bf3e33df2d6d3d46984e7cded414902b166cfddc94L188-R194)