### PR TITLE
Bugfix: fix messaging

### DIFF
--- a/Jenkinsfile_DEV
+++ b/Jenkinsfile_DEV
@@ -69,11 +69,6 @@ pipeline {
                         discord.redzone.channel.id=1309027165228109824
                         discord.scores.channel.id=1309027178780033074
 
-                        # Role IDs
-                        discord.fbs.close_game.role.id=1330667771452723332
-                        discord.fcs.close_game.role.id=1330667813207277748
-                        discord.upset_alert.role.id=1330667830873559171
-
                         # Domain configuration
                         api.url=https://dev.api.fakecollegefootball.com/arceus
 

--- a/Jenkinsfile_PRD
+++ b/Jenkinsfile_PRD
@@ -69,11 +69,6 @@ pipeline {
                         discord.redzone.channel.id=1309026273372274739
                         discord.scores.channel.id=1309026439001280552
 
-                        # Role IDs
-                        discord.fbs.close_game.role.id=1182500660441256006
-                        discord.fcs.close_game.role.id=1182501996645855243
-                        discord.upset_alert.role.id=1330664603734118513
-
                         # Domain configuration
                         api.url=https://api.fakecollegefootball.com/arceus
 

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/CloseGameHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/CloseGameHandler.kt
@@ -30,10 +30,7 @@ class CloseGameHandler(
             return null
         }
 
-        val guild = client.getGuild(Snowflake(properties.getDiscordProperties().guildId))
-        val fbsCloseGameRole = guild.getRole(Snowflake(properties.getDiscordProperties().fbsCloseGameRoleId))
-        val fcsCloseGameRole = guild.getRole(Snowflake(properties.getDiscordProperties().fcsCloseGameRoleId))
-        var messageContent = fbsCloseGameRole.mention + " " + fcsCloseGameRole.mention + "\n"
+        var messageContent = "**CLOSE GAME ALERT**\n"
         messageContent +=
             if (game.homeScore == game.awayScore) {
                 if (game.quarter >= 5) {

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/UpsetAlertHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/UpsetAlertHandler.kt
@@ -40,9 +40,7 @@ class UpsetAlertHandler(
 
         val teamOnUpsetAlert = if (homeTeamRanking < awayTeamRanking) homeTeam else awayTeam
 
-        val guild = client.getGuild(Snowflake(properties.getDiscordProperties().guildId))
-        val upsetAlertRole = guild.getRole(Snowflake(properties.getDiscordProperties().upsetAlertRoleId))
-        var messageContent = upsetAlertRole.mention + "\n"
+        var messageContent = "**UPSET ALERT**\n"
         messageContent += "#${if (teamOnUpsetAlert.name == homeTeam.name) homeTeamRanking else awayTeamRanking} " +
             "${teamOnUpsetAlert.name} is at risk of losing to " +
             "${if (teamOnUpsetAlert.name == homeTeam.name) awayTeam.name else homeTeam.name} late in the game.\n\n"

--- a/src/main/kotlin/com/fcfb/discord/refbot/model/discord/DiscordProperties.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/model/discord/DiscordProperties.kt
@@ -7,8 +7,5 @@ data class DiscordProperties(
     val postgameChannelId: String,
     val redzoneChannelId: String,
     val scoresChannelId: String,
-    val fbsCloseGameRoleId: String,
-    val fcsCloseGameRoleId: String,
-    val upsetAlertRoleId: String,
     val botId: String,
 )

--- a/src/main/kotlin/com/fcfb/discord/refbot/model/discord/MessageConstants.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/model/discord/MessageConstants.kt
@@ -4,7 +4,10 @@ import com.fcfb.discord.refbot.utils.Logger
 
 class MessageConstants {
     enum class Error(val message: String) {
-        NO_GAME_FOUND("Could not find a game associated with this number request message."),
+        NO_GAME_FOUND(
+            "Could not find a game associated with this number request message. " +
+                "Please try to regenerate the play message with `/ping`",
+        ),
         WAITING_FOR_NUMBER_IN_DMS("This game is currently waiting on a number from you in your DMs"),
         WAITING_FOR_COIN_TOSS("This game is currently waiting on the away coach to call **heads** or **tails**"),
         WAITING_FOR_COIN_TOSS_CHOICE("This game is currently waiting on the coin toss winning coach to call **receive** or **defer**"),

--- a/src/main/kotlin/com/fcfb/discord/refbot/utils/Properties.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/utils/Properties.kt
@@ -16,9 +16,6 @@ class Properties {
         val postgameChannelId = properties.getProperty("discord.postgame.forum.id")
         val redzoneChannelId = properties.getProperty("discord.redzone.channel.id")
         val scoresChannelId = properties.getProperty("discord.scores.channel.id")
-        val fbsCloseGameRoleId = properties.getProperty("discord.fbs.close_game.role.id")
-        val fcsCloseGameRoleId = properties.getProperty("discord.fcs.close_game.role.id")
-        val upsetAlertRoleId = properties.getProperty("discord.upset_alert.role.id")
         val botId = properties.getProperty("discord.bot.id")
         return DiscordProperties(
             token,
@@ -27,9 +24,6 @@ class Properties {
             postgameChannelId,
             redzoneChannelId,
             scoresChannelId,
-            fbsCloseGameRoleId,
-            fcsCloseGameRoleId,
-            upsetAlertRoleId,
             botId,
         )
     }


### PR DESCRIPTION
This pull request includes several changes to the codebase, primarily focusing on removing unused role IDs and updating message content in the Discord bot handlers. The most important changes are listed below:

### Removal of Unused Role IDs:

* [`Jenkinsfile_DEV`](diffhunk://#diff-31a677167e5385c4784b06857b7ad66d43d5b296ba76db130cf8895fc9a9e603L72-L76): Removed unused Discord role IDs for close game and upset alert notifications.
* [`Jenkinsfile_PRD`](diffhunk://#diff-699c3d312a84bf08622aa65c3256fe29155c00fb46a3da4415b72dbc8c9eb635L72-L76): Removed unused Discord role IDs for close game and upset alert notifications.
* [`src/main/kotlin/com/fcfb/discord/refbot/model/discord/DiscordProperties.kt`](diffhunk://#diff-883133c5e82ab0f0e6d1556e4043a3bc268a811319da8eeabafdb70f21ec71e1L10-L12): Removed unused properties for Discord role IDs.

### Update of Message Content:

* [`src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/CloseGameHandler.kt`](diffhunk://#diff-6feafd84790d8703cf417c7d6d148b2b0a7d35e2bdde353637fba64cf30517d8L33-R33): Updated the message content to remove role mentions and replace them with a generic close game alert message.
* [`src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/UpsetAlertHandler.kt`](diffhunk://#diff-f6dfe6179dc6d99707efadd4b923d0f5a8b30e5cb44464bdfcc32238926ae30cL43-R43): Updated the message content to remove role mentions and replace them with a generic upset alert message.