### PR TITLE
Bugfix: fix get ongoing games

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/api/GameClient.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/api/GameClient.kt
@@ -221,7 +221,7 @@ class GameClient {
      * @return List<Game>
      */
     internal suspend fun getAllOngoingGames(): List<Game>? {
-        val endpointUrl = "$baseUrl/game/all/ongoing"
+        val endpointUrl = "$baseUrl/game/filtered?category=ONGOING"
         return getRequestList(endpointUrl)
     }
 


### PR DESCRIPTION
This pull request includes a change to the `GameClient` class in the `src/main/kotlin/com/fcfb/discord/refbot/api/GameClient.kt` file. The change updates the endpoint URL used in the `getAllOngoingGames` method to filter games by category.

Codebase modification:

* [`src/main/kotlin/com/fcfb/discord/refbot/api/GameClient.kt`](diffhunk://#diff-79710734a21251e11d2396dd0431dea6d1ff3a37aeb36832b4b3dd7a5d33f25eL224-R224): Modified the `getAllOngoingGames` method to use the updated endpoint URL `$baseUrl/game/filtered?category=ONGOING` instead of `$baseUrl/game/all/ongoing`.