### PR TITLE
Feature: add team active param

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/model/fcfb/Team.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/model/fcfb/Team.kt
@@ -43,6 +43,7 @@ data class Team(
     @JsonProperty("playoff_losses") var playoffLosses: Int = 0,
     @JsonProperty("national_championship_wins") var nationalChampionshipWins: Int = 0,
     @JsonProperty("national_championship_losses") var nationalChampionshipLosses: Int = 0,
+    @JsonProperty("active") var active: Boolean = true,
 )
 
 enum class Conference(val description: String) {


### PR DESCRIPTION
This pull request includes a change to the `Team` data class in the `src/main/kotlin/com/fcfb/discord/refbot/model/fcfb/Team.kt` file. The change adds a new property to indicate whether a team is active.

* [`src/main/kotlin/com/fcfb/discord/refbot/model/fcfb/Team.kt`](diffhunk://#diff-8c54eff55924f2372ff08e2a07cdebe53979688b5fcfabbd0e0bfaa35dca151dR46): Added a new property `active` to the `Team` data class to track if a team is currently active.