### PR TITLE
Bugfix: fix timeout message when team has no timeouts

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -229,8 +229,8 @@ class DiscordMessageHandler(
         val baseMessage = Info.SUCCESSFUL_NUMBER_SUBMISSION.message.format(number)
         val messageContent =
             if (timeoutCalled) {
-                if ((game.possession == TeamSide.HOME && game.homeTimeouts == 0) ||
-                    (game.possession == TeamSide.AWAY && game.awayTimeouts == 0)
+                if ((game.possession == TeamSide.HOME && game.awayTimeouts == 0) ||
+                    (game.possession == TeamSide.AWAY && game.homeTimeouts == 0)
                 ) {
                     "$baseMessage. You have no timeouts remaining so not calling timeout."
                 } else {


### PR DESCRIPTION
This pull request includes a correction to the timeout logic in the `DiscordMessageHandler` class to ensure the correct team's timeout count is checked.

* [`src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt`](diffhunk://#diff-568a86bf250710df5b654ac68ab48d77e650d338d6e0f018c6f951dadc74f8a3L232-R233): Corrected the condition to check the correct team's timeout count when deciding whether to call a timeout.