### PR TITLE
Bugfix: fix ranking logic to only use one or the other

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/UpsetAlertHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/UpsetAlertHandler.kt
@@ -41,10 +41,8 @@ class UpsetAlertHandler(
             Logger.error("Error getting away team for upset alert: ${awayTeamApiResponse.values.firstOrNull()}")
         }
         val awayTeam = awayTeamApiResponse.keys.firstOrNull() ?: return null
-        var homeTeamRanking = if (homeTeam.playoffCommitteeRanking == 0) homeTeam.coachesPollRanking else homeTeam.playoffCommitteeRanking
-        var awayTeamRanking = if (awayTeam.playoffCommitteeRanking == 0) awayTeam.coachesPollRanking else awayTeam.playoffCommitteeRanking
-        homeTeamRanking = if (homeTeamRanking == 0 || homeTeamRanking == null) 100 else homeTeamRanking
-        awayTeamRanking = if (awayTeamRanking == 0 || awayTeamRanking == null) 100 else awayTeamRanking
+        val homeTeamRanking = game.homeTeamRank ?: 100
+        val awayTeamRanking = game.awayTeamRank ?: 100
 
         val teamOnUpsetAlert = if (homeTeamRanking < awayTeamRanking) homeTeam else awayTeam
 

--- a/src/main/kotlin/com/fcfb/discord/refbot/utils/GameUtils.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/utils/GameUtils.kt
@@ -611,22 +611,11 @@ class GameUtils(
     }
 
     /**
-     * Get the teams rank for a game
-     * @param game The game object
-     */
-    private suspend fun getTeamRankings(game: Game): Pair<Int?, Int?> {
-        val (homeTeam, awayTeam) = getTeams(game)
-        val homeTeamRank = homeTeam?.playoffCommitteeRanking ?: homeTeam?.coachesPollRanking
-        val awayTeamRank = awayTeam?.playoffCommitteeRanking ?: awayTeam?.coachesPollRanking
-
-        return Pair(homeTeamRank, awayTeamRank)
-    }
-
-    /**
      * Get the formatted team names for posting
      */
-    suspend fun getFormattedTeamNames(game: Game): Pair<String, String> {
-        val (homeTeamRank, awayTeamRank) = getTeamRankings(game)
+    fun getFormattedTeamNames(game: Game): Pair<String, String> {
+        val homeTeamRank = game.homeTeamRank
+        val awayTeamRank = game.awayTeamRank
         val formattedHomeTeam = if (homeTeamRank != null && homeTeamRank != 0) "#$homeTeamRank ${game.homeTeam}" else game.homeTeam
         val formattedAwayTeam = if (awayTeamRank != null && awayTeamRank != 0) "#$awayTeamRank ${game.awayTeam}" else game.awayTeam
         return Pair(formattedHomeTeam, formattedAwayTeam)


### PR DESCRIPTION
This pull request refactors the handling of team rankings in the `UpsetAlertHandler` and `GameUtils` classes to simplify the code and improve maintainability. The changes replace custom ranking logic with direct usage of `Game` object properties.

### Refactoring of team ranking logic:

* [`src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/UpsetAlertHandler.kt`](diffhunk://#diff-f6dfe6179dc6d99707efadd4b923d0f5a8b30e5cb44464bdfcc32238926ae30cL44-R45): Simplified the ranking logic by directly using `game.homeTeamRank` and `game.awayTeamRank` properties, with a fallback to `100` if the rank is null. This removes redundant checks and improves readability.
* [`src/main/kotlin/com/fcfb/discord/refbot/utils/GameUtils.kt`](diffhunk://#diff-5633f51e8de370954546f81f66331ed416f63ed77945a06215f9c2c333b3ff7cL613-R618): Removed the `getTeamRankings` method and updated `getFormattedTeamNames` to directly access `game.homeTeamRank` and `game.awayTeamRank`. This eliminates unnecessary indirection and makes the code more concise.