### PR TITLE
Bugfix: fix playoff tag duplicate error

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/TextChannelThreadHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/TextChannelThreadHandler.kt
@@ -239,12 +239,6 @@ class TextChannelThreadHandler(
             }
         }
 
-        val tags = availableTags.filter { it.name == game.gameType?.description }.map { it.id }
-
-        for (tag in tags) {
-            tagsToApply.add(tag)
-        }
-
         return tagsToApply
     }
 


### PR DESCRIPTION
This pull request simplifies the `TextChannelThreadHandler` class by removing redundant code related to filtering and adding tags to the `tagsToApply` list.

Code simplification:

* [`src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/TextChannelThreadHandler.kt`](diffhunk://#diff-b57dfdf3cfcaf766fdb3e54ae573c089252a5740f40a6e48c60dd09cab1c25d5L242-L247): Removed unnecessary filtering and mapping of `availableTags` to streamline the process of returning `tagsToApply`.