### PR TITLE
Update StartGameCommand.kt - Added channels

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartGameCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartGameCommand.kt
@@ -43,6 +43,16 @@ class StartGameCommand(
                     choice("FS1", "FS1"),
                     choice("FS2", "FS2"),
                     choice("NBC", "NBC"),
+                    choice("ACC Network", "ACC Network"),
+                    choice("Big Ten Network","Big Ten Network"),
+                    choice("CBS Sports Network","CBS Sports Network"),
+                    choice("The CW","The CW"),
+                    choice("ESPNU","ESPNU"),
+                    choice("ESPN+","ESPN+"),
+                    choice("SEC Network"),
+                    choice("TNT","TNT"),
+                    choice("PAC-12 Network","PAC-12 Network"),
+                    choice("Peacock","Peacock"),
                 )
             }
             string("game_type", "Game Type") {
@@ -136,6 +146,15 @@ class StartGameCommand(
                 }
                 "SEC Network" -> {
                     TVChannel.SEC_NETWORK
+                }
+                "TNT" -> {
+                    TVChannel.TNT
+                }
+                "PAC-12 Network" -> {
+                    TVChannel.PAC_12_NETWORK
+                }
+                "Peacock" -> {
+                    TVChannel.PEACOCK
                 }
                 else -> null
             }

--- a/src/main/kotlin/com/fcfb/discord/refbot/model/enums/game/TVChannel.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/model/enums/game/TVChannel.kt
@@ -16,4 +16,7 @@ enum class TVChannel(val description: String) {
     ESPNU("ESPNU"),
     ESPN_PLUS("ESPN+"),
     SEC_NETWORK("SEC Network"),
+    TNT("TNT"),
+	PAC_12_NETWORK("PAC-12 Network"),
+	PEACOCK("Peacock")
 }


### PR DESCRIPTION
Added channels to both the command drop down choices and the tvChannel setting portion.

Added ACC Network, Big Ten Network, CBS Sports, CW, ESPNU, ESPN+, SEC Network to just the choices portion

Added TNT, Pac-12 network, and Peacock to both the choices portion and the tvChannel setting portion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands `tv_channel` dropdown options and adds/handles `TNT`, `PAC-12 Network`, and `Peacock` via new enum values and command mappings.
> 
> - **Game Command (`StartGameCommand.kt`)**:
>   - **TV Channel choices**: Adds `ACC Network`, `Big Ten Network`, `CBS Sports Network`, `The CW`, `ESPNU`, `ESPN+`, `SEC Network`, `TNT`, `PAC-12 Network`, `Peacock` to `tv_channel` dropdown.
>   - **Channel mapping**: Maps `TNT`, `PAC-12 Network`, and `Peacock` to `TVChannel` (`TNT`, `PAC_12_NETWORK`, `PEACOCK`).
> - **Model Enum (`TVChannel.kt`)**:
>   - Adds enum values: `TNT`, `PAC_12_NETWORK`, `PEACOCK`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef1fc7d51a1250192343ff46e3afe59ff935bda7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->