### PR TITLE
Update TVChannel.kt - ESPNEWS

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/model/enums/game/TVChannel.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/model/enums/game/TVChannel.kt
@@ -19,4 +19,5 @@ enum class TVChannel(val description: String) {
     TNT("TNT"),
     PAC_12_NETWORK("PAC-12 Network"),
     PEACOCK("Peacock"),
+    ESPNEWS("ESPNEWS"),
 }


### PR DESCRIPTION
I forgot ESPNEWS last game week. This now has all 19 channels that Scavni uses in their tv listings.