### PR TITLE
Add chew game message

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -806,7 +806,7 @@ class DiscordMessageHandler(
                 "{result}" to result,
                 "{timeout_called}" to gameUtils.getTimeoutMessage(game, play, timeoutCalled),
                 "{clock_status}" to if (game.clockStopped) "The clock is stopped." else "The clock is running.",
-                "{game_status}" to if (game.gameMode == GameMode.CHEW) "The game is in chew mode" else "",
+                "{game_status}" to if (game.gameMode == GameMode.CHEW) "The game is in chew mode." else "",
                 "{ball_location}" to gameUtils.getLocationDescription(game),
                 "{ball_location_scenario}" to gameUtils.getBallLocationScenarioMessage(game, play),
                 "{dog_deadline}" to game.gameTimer.toString(),

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -9,6 +9,7 @@ import com.fcfb.discord.refbot.api.user.FCFBUserClient
 import com.fcfb.discord.refbot.handlers.system.FileHandler
 import com.fcfb.discord.refbot.model.domain.Game
 import com.fcfb.discord.refbot.model.domain.Play
+import com.fcfb.discord.refbot.model.enums.game.GameMode
 import com.fcfb.discord.refbot.model.enums.game.GameStatus
 import com.fcfb.discord.refbot.model.enums.game.GameType
 import com.fcfb.discord.refbot.model.enums.message.Error

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -806,7 +806,7 @@ class DiscordMessageHandler(
                 "{result}" to result,
                 "{timeout_called}" to gameUtils.getTimeoutMessage(game, play, timeoutCalled),
                 "{clock_status}" to if (game.clockStopped) "The clock is stopped." else "The clock is running.",
-                "{game_status}" to if (game.gameMode == GameMode.CHEW) "The game is in chew mode." else "",
+                "{game_status}" to if (game.gameMode == GameMode.CHEW) " The game is in chew mode." else "",
                 "{ball_location}" to gameUtils.getLocationDescription(game),
                 "{ball_location_scenario}" to gameUtils.getBallLocationScenarioMessage(game, play),
                 "{dog_deadline}" to game.gameTimer.toString(),

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -806,6 +806,7 @@ class DiscordMessageHandler(
                 "{result}" to result,
                 "{timeout_called}" to gameUtils.getTimeoutMessage(game, play, timeoutCalled),
                 "{clock_status}" to if (game.clockStopped) "The clock is stopped." else "The clock is running.",
+                "{game_status}" to if (game.gameMode == GameMode.CHEW) "The game is in chew mode" else "",
                 "{ball_location}" to gameUtils.getLocationDescription(game),
                 "{ball_location_scenario}" to gameUtils.getBallLocationScenarioMessage(game, play),
                 "{dog_deadline}" to game.gameTimer.toString(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `{game_status}` placeholder to game messages that indicates when the game is in chew mode.
> 
> - **Discord message handling** (`DiscordMessageHandler.kt`):
>   - Add `GameMode` import.
>   - Extend message placeholder replacements with `{game_status}` to append "The game is in chew mode." when `game.gameMode == GameMode.CHEW`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb26b2cdb3b89919fbb36e4270cf23852bf3c2d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->