### PR TITLE
Implement scheduling

### DIFF
--- a/src/main/kotlin/com/fcfb/discord/refbot/api/game/GameClient.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/api/game/GameClient.kt
@@ -270,7 +270,8 @@ class GameClient(
             }
             val objectMapper = JacksonConfig().configureGameMapping()
             val node = objectMapper.readTree(jsonResponse)
-            val jobId = node.get("jobId")?.asText()
+            // Use snake_case key to match API response (readTree doesn't apply naming strategy)
+            val jobId = node.get("job_id")?.asText() ?: node.get("jobId")?.asText()
             mapOf(jobId to null)
         } catch (e: Exception) {
             Logger.error(e.message ?: "Unknown error occurred while starting week")
@@ -317,7 +318,8 @@ class GameClient(
             }
             val objectMapper = JacksonConfig().configureGameMapping()
             val node = objectMapper.readTree(jsonResponse)
-            val newJobId = node.get("jobId")?.asText()
+            // Use snake_case key to match API response (readTree doesn't apply naming strategy)
+            val newJobId = node.get("job_id")?.asText() ?: node.get("jobId")?.asText()
             mapOf(newJobId to null)
         } catch (e: Exception) {
             Logger.error(e.message ?: "Unknown error occurred while retrying failed games")

--- a/src/main/kotlin/com/fcfb/discord/refbot/api/game/GameClient.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/api/game/GameClient.kt
@@ -253,6 +253,83 @@ class GameClient(
     }
 
     /**
+     * Start all games for a given season and week (async).
+     * Returns immediately with a job ID. Use [getGameWeekJobStatus] to poll progress.
+     */
+    internal suspend fun startWeek(
+        season: Int,
+        week: Int,
+    ): Map<String?, String?> {
+        val endpointUrl = "$baseUrl/game/week?season=$season&week=$week"
+        return try {
+            val response: HttpResponse = httpClient.post(endpointUrl)
+            val jsonResponse = response.bodyAsText()
+            if (jsonResponse.contains("error")) {
+                val error = apiUtils.readError(jsonResponse)
+                return mapOf(null to error)
+            }
+            val objectMapper = JacksonConfig().configureGameMapping()
+            val node = objectMapper.readTree(jsonResponse)
+            val jobId = node.get("jobId")?.asText()
+            mapOf(jobId to null)
+        } catch (e: Exception) {
+            Logger.error(e.message ?: "Unknown error occurred while starting week")
+            if (e.message!!.contains("Connection refused")) {
+                mapOf(null to "Connection refused. Arceus API is likely not running.")
+            } else {
+                mapOf(null to e.message)
+            }
+        }
+    }
+
+    /**
+     * Poll the status of a game week start job.
+     * Returns a map with job status JSON fields.
+     */
+    internal suspend fun getGameWeekJobStatus(jobId: String): Map<String, Any?>? {
+        val endpointUrl = "$baseUrl/game/week/status/$jobId"
+        return try {
+            val response =
+                httpClient.get(endpointUrl) {
+                    contentType(ContentType.Application.Json)
+                }
+            val jsonResponse = response.bodyAsText()
+            val objectMapper = JacksonConfig().configureGameMapping()
+            objectMapper.readValue(jsonResponse, object : com.fasterxml.jackson.core.type.TypeReference<Map<String, Any?>>() {})
+        } catch (e: Exception) {
+            Logger.error("Error polling job status: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Retry failed games from a previously completed job.
+     * Returns immediately with a new job ID.
+     */
+    internal suspend fun retryFailedGames(jobId: String): Map<String?, String?> {
+        val endpointUrl = "$baseUrl/game/week/retry/$jobId"
+        return try {
+            val response: HttpResponse = httpClient.post(endpointUrl)
+            val jsonResponse = response.bodyAsText()
+            if (jsonResponse.contains("error")) {
+                val error = apiUtils.readError(jsonResponse)
+                return mapOf(null to error)
+            }
+            val objectMapper = JacksonConfig().configureGameMapping()
+            val node = objectMapper.readTree(jsonResponse)
+            val newJobId = node.get("jobId")?.asText()
+            mapOf(newJobId to null)
+        } catch (e: Exception) {
+            Logger.error(e.message ?: "Unknown error occurred while retrying failed games")
+            if (e.message!!.contains("Connection refused")) {
+                mapOf(null to "Connection refused. Arceus API is likely not running.")
+            } else {
+                mapOf(null to e.message)
+            }
+        }
+    }
+
+    /**
      * Call a put request to the game endpoint and return a game
      * @param endpointUrl
      * @return Game

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/RetryWeekCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/RetryWeekCommand.kt
@@ -1,0 +1,120 @@
+package com.fcfb.discord.refbot.commands.game
+
+import com.fcfb.discord.refbot.api.game.GameClient
+import com.fcfb.discord.refbot.utils.system.Logger
+import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.response.respond
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.rest.builder.interaction.string
+import kotlinx.coroutines.delay
+
+class RetryWeekCommand(
+    private val gameClient: GameClient,
+) {
+    companion object {
+        private const val POLL_INTERVAL_MS = 5000L
+        private const val MAX_POLL_ATTEMPTS = 720
+    }
+
+    suspend fun register(client: Kord) {
+        client.createGlobalChatInputCommand(
+            "retry_week",
+            "Retry failed games from a previous start_week job",
+        ) {
+            string("job_id", "The job ID from the original start_week command") {
+                required = true
+            }
+        }
+    }
+
+    /**
+     * Retry failed games from a previous start_week job.
+     * Sends the retry request to the backend, then polls for progress.
+     */
+    suspend fun execute(interaction: ChatInputCommandInteraction) {
+        val command = interaction.command
+        val jobId = command.options["job_id"]!!.value.toString()
+
+        Logger.info("${interaction.user.username} is retrying failed games for job $jobId")
+        val response = interaction.deferPublicResponse()
+
+        response.respond {
+            this.content = "Retrying failed games for job `$jobId`..."
+        }
+
+        try {
+            val result = gameClient.retryFailedGames(jobId)
+            val newJobId = result.keys.firstOrNull()
+            val error = result.values.firstOrNull()
+
+            if (newJobId == null) {
+                response.respond {
+                    this.content = "FAILED: Could not retry failed games: ${error ?: "Unknown error"}"
+                }
+                Logger.error("Failed to retry games: $error")
+                return
+            }
+
+            Logger.info("Retry job $newJobId created from original job $jobId")
+
+            response.respond {
+                this.content = "Retry job started: `$newJobId`\nPolling for progress..."
+            }
+
+            for (attempt in 1..MAX_POLL_ATTEMPTS) {
+                delay(POLL_INTERVAL_MS)
+
+                val status = gameClient.getGameWeekJobStatus(newJobId) ?: continue
+
+                val jobStatus = status["status"] as? String ?: "UNKNOWN"
+                val totalGames = (status["totalGames"] as? Number)?.toInt() ?: 0
+                val startedGames = (status["startedGames"] as? Number)?.toInt() ?: 0
+                val failedGames = (status["failedGames"] as? Number)?.toInt() ?: 0
+                val currentIndex = (status["currentIndex"] as? Number)?.toInt() ?: 0
+
+                val progressBar = buildProgressBar(currentIndex, totalGames)
+
+                val message = buildString {
+                    appendLine("**Retry Job -- `$newJobId`**")
+                    appendLine("(Original job: `$jobId`)")
+                    appendLine()
+                    appendLine(progressBar)
+                    appendLine()
+                    appendLine("**Progress:** $currentIndex / $totalGames games processed")
+                    appendLine("Started: $startedGames | Failed: $failedGames")
+
+                    if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
+                        appendLine()
+                        if (failedGames > 0) {
+                            appendLine("Retry completed with $failedGames failure(s). Use `/retry_week` again with job ID `$newJobId` to retry remaining failures.")
+                        } else {
+                            appendLine("All $startedGames retried games started successfully!")
+                        }
+                    }
+                }
+
+                response.respond {
+                    this.content = message
+                }
+
+                if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
+                    Logger.info("Retry job $newJobId finished: $jobStatus (started=$startedGames, failed=$failedGames)")
+                    break
+                }
+            }
+        } catch (e: Exception) {
+            Logger.error("Error in retry week command: ${e.message}")
+            response.respond {
+                this.content = "FAILED: Error retrying games: ${e.message}"
+            }
+        }
+    }
+
+    private fun buildProgressBar(current: Int, total: Int): String {
+        if (total == 0) return "`[--------------------] 0%`"
+        val percent = (current.toDouble() / total * 100).toInt().coerceIn(0, 100)
+        val filled = (percent / 5).coerceIn(0, 20)
+        val empty = 20 - filled
+        return "`[${"#".repeat(filled)}${"-".repeat(empty)}] $percent%`"
+    }
+}

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/RetryWeekCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/RetryWeekCommand.kt
@@ -1,6 +1,7 @@
 package com.fcfb.discord.refbot.commands.game
 
 import com.fcfb.discord.refbot.api.game.GameClient
+import com.fcfb.discord.refbot.utils.ProgressBarUtils
 import com.fcfb.discord.refbot.utils.system.Logger
 import dev.kord.core.Kord
 import dev.kord.core.behavior.interaction.response.respond
@@ -72,7 +73,7 @@ class RetryWeekCommand(
                 val failedGames = (status["failedGames"] as? Number)?.toInt() ?: 0
                 val currentIndex = (status["currentIndex"] as? Number)?.toInt() ?: 0
 
-                val progressBar = buildProgressBar(currentIndex, totalGames)
+                val progressBar = ProgressBarUtils.buildProgressBar(currentIndex, totalGames)
 
                 val message =
                     buildString {
@@ -114,14 +115,4 @@ class RetryWeekCommand(
         }
     }
 
-    private fun buildProgressBar(
-        current: Int,
-        total: Int,
-    ): String {
-        if (total == 0) return "`[--------------------] 0%`"
-        val percent = (current.toDouble() / total * 100).toInt().coerceIn(0, 100)
-        val filled = (percent / 5).coerceIn(0, 20)
-        val empty = 20 - filled
-        return "`[${"#".repeat(filled)}${"-".repeat(empty)}] $percent%`"
-    }
 }

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/RetryWeekCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/RetryWeekCommand.kt
@@ -74,24 +74,28 @@ class RetryWeekCommand(
 
                 val progressBar = buildProgressBar(currentIndex, totalGames)
 
-                val message = buildString {
-                    appendLine("**Retry Job -- `$newJobId`**")
-                    appendLine("(Original job: `$jobId`)")
-                    appendLine()
-                    appendLine(progressBar)
-                    appendLine()
-                    appendLine("**Progress:** $currentIndex / $totalGames games processed")
-                    appendLine("Started: $startedGames | Failed: $failedGames")
-
-                    if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
+                val message =
+                    buildString {
+                        appendLine("**Retry Job -- `$newJobId`**")
+                        appendLine("(Original job: `$jobId`)")
                         appendLine()
-                        if (failedGames > 0) {
-                            appendLine("Retry completed with $failedGames failure(s). Use `/retry_week` again with job ID `$newJobId` to retry remaining failures.")
-                        } else {
-                            appendLine("All $startedGames retried games started successfully!")
+                        appendLine(progressBar)
+                        appendLine()
+                        appendLine("**Progress:** $currentIndex / $totalGames games processed")
+                        appendLine("Started: $startedGames | Failed: $failedGames")
+
+                        if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
+                            appendLine()
+                            if (failedGames > 0) {
+                                appendLine(
+                                    "Retry completed with $failedGames failure(s). " +
+                                        "Use `/retry_week` again with job ID `$newJobId` to retry remaining failures.",
+                                )
+                            } else {
+                                appendLine("All $startedGames retried games started successfully!")
+                            }
                         }
                     }
-                }
 
                 response.respond {
                     this.content = message
@@ -110,7 +114,10 @@ class RetryWeekCommand(
         }
     }
 
-    private fun buildProgressBar(current: Int, total: Int): String {
+    private fun buildProgressBar(
+        current: Int,
+        total: Int,
+    ): String {
         if (total == 0) return "`[--------------------] 0%`"
         val percent = (current.toDouble() / total * 100).toInt().coerceIn(0, 100)
         val filled = (percent / 5).coerceIn(0, 20)

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/RetryWeekCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/RetryWeekCommand.kt
@@ -111,7 +111,10 @@ class RetryWeekCommand(
             }
 
             if (!jobCompleted) {
-                Logger.warn("Polling timeout: Retry job $newJobId did not complete within ${MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS / 1000 / 60} minutes")
+                val timeoutMinutes = MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS / 1000 / 60
+                Logger.warn(
+                    "Polling timeout: Retry job $newJobId did not complete within $timeoutMinutes minutes",
+                )
                 response.respond {
                     this.content = "**⚠️ Polling Timeout**\n\n" +
                         "Polling stopped after ${MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS / 1000 / 60} minutes. " +
@@ -128,5 +131,4 @@ class RetryWeekCommand(
             }
         }
     }
-
 }

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/RetryWeekCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/RetryWeekCommand.kt
@@ -62,7 +62,6 @@ class RetryWeekCommand(
             val pollingResult =
                 GameWeekPollingUtils.pollGameWeekJob(
                     gameClient = gameClient,
-                    interaction = interaction,
                     response = response,
                     config =
                         GameWeekPollingUtils.PollingConfig(
@@ -81,8 +80,8 @@ class RetryWeekCommand(
                                 }
                             },
                             onTimeout = { retryJobId ->
-                                val timeoutMinutes = 720 * 5000L / 1000 / 60
-                                "**⚠️ Polling Timeout**\n\n" +
+                                val timeoutMinutes = GameWeekPollingUtils.getTimeoutMinutes()
+                                "**Polling Timeout**\n\n" +
                                     "Polling stopped after $timeoutMinutes minutes. " +
                                     "The retry job may still be running in the background.\n\n" +
                                     "Retry Job ID: `$retryJobId`\n" +

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
@@ -76,24 +76,28 @@ class StartWeekCommand(
 
                 val progressBar = buildProgressBar(currentIndex, totalGames)
 
-                val message = buildString {
-                    appendLine("**Game Week Start -- Season $season, Week $week**")
-                    appendLine()
-                    appendLine(progressBar)
-                    appendLine()
-                    appendLine("**Progress:** $currentIndex / $totalGames games processed")
-                    appendLine("Started: $startedGames | Failed: $failedGames")
-
-                    if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
+                val message =
+                    buildString {
+                        appendLine("**Game Week Start -- Season $season, Week $week**")
                         appendLine()
-                        if (failedGames > 0) {
-                            appendLine("Completed with $failedGames failure(s). Use `/retry_week` or the website to retry failed games.")
-                            appendLine("Job ID: `$jobId`")
-                        } else {
-                            appendLine("All $startedGames games started successfully!")
+                        appendLine(progressBar)
+                        appendLine()
+                        appendLine("**Progress:** $currentIndex / $totalGames games processed")
+                        appendLine("Started: $startedGames | Failed: $failedGames")
+
+                        if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
+                            appendLine()
+                            if (failedGames > 0) {
+                                appendLine(
+                                    "Completed with $failedGames failure(s). " +
+                                        "Use `/retry_week` or the website to retry failed games.",
+                                )
+                                appendLine("Job ID: `$jobId`")
+                            } else {
+                                appendLine("All $startedGames games started successfully!")
+                            }
                         }
                     }
-                }
 
                 response.respond {
                     this.content = message
@@ -112,7 +116,10 @@ class StartWeekCommand(
         }
     }
 
-    private fun buildProgressBar(current: Int, total: Int): String {
+    private fun buildProgressBar(
+        current: Int,
+        total: Int,
+    ): String {
         if (total == 0) return "`[--------------------] 0%`"
         val percent = (current.toDouble() / total * 100).toInt().coerceIn(0, 100)
         val filled = (percent / 5).coerceIn(0, 20)

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
@@ -113,7 +113,9 @@ class StartWeekCommand(
             }
 
             if (!jobCompleted) {
-                Logger.warn("Polling timeout: Job $jobId did not complete within ${MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS / 1000 / 60} minutes")
+                Logger.warn(
+                    "Polling timeout: Job $jobId did not complete within ${MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS / 1000 / 60} minutes",
+                )
                 response.respond {
                     this.content = "**⚠️ Polling Timeout**\n\n" +
                         "Polling stopped after ${MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS / 1000 / 60} minutes. " +
@@ -129,5 +131,4 @@ class StartWeekCommand(
             }
         }
     }
-
 }

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
@@ -1,6 +1,7 @@
 package com.fcfb.discord.refbot.commands.game
 
 import com.fcfb.discord.refbot.api.game.GameClient
+import com.fcfb.discord.refbot.utils.ProgressBarUtils
 import com.fcfb.discord.refbot.utils.system.Logger
 import dev.kord.core.Kord
 import dev.kord.core.behavior.interaction.response.respond
@@ -74,7 +75,7 @@ class StartWeekCommand(
                 val failedGames = (status["failedGames"] as? Number)?.toInt() ?: 0
                 val currentIndex = (status["currentIndex"] as? Number)?.toInt() ?: 0
 
-                val progressBar = buildProgressBar(currentIndex, totalGames)
+                val progressBar = ProgressBarUtils.buildProgressBar(currentIndex, totalGames)
 
                 val message =
                     buildString {
@@ -116,14 +117,4 @@ class StartWeekCommand(
         }
     }
 
-    private fun buildProgressBar(
-        current: Int,
-        total: Int,
-    ): String {
-        if (total == 0) return "`[--------------------] 0%`"
-        val percent = (current.toDouble() / total * 100).toInt().coerceIn(0, 100)
-        val filled = (percent / 5).coerceIn(0, 20)
-        val empty = 20 - filled
-        return "`[${"#".repeat(filled)}${"-".repeat(empty)}] $percent%`"
-    }
 }

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
@@ -1,0 +1,122 @@
+package com.fcfb.discord.refbot.commands.game
+
+import com.fcfb.discord.refbot.api.game.GameClient
+import com.fcfb.discord.refbot.utils.system.Logger
+import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.response.respond
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.rest.builder.interaction.integer
+import kotlinx.coroutines.delay
+
+class StartWeekCommand(
+    private val gameClient: GameClient,
+) {
+    companion object {
+        private const val POLL_INTERVAL_MS = 5000L
+        private const val MAX_POLL_ATTEMPTS = 720
+    }
+
+    suspend fun register(client: Kord) {
+        client.createGlobalChatInputCommand(
+            "start_week",
+            "Start all games for a given week",
+        ) {
+            integer("season", "Season number") {
+                required = true
+            }
+            integer("week", "Week number") {
+                required = true
+            }
+        }
+    }
+
+    /**
+     * Start all games for a given week.
+     * Sends the request to the backend, then polls for progress and
+     * edits the Discord message with updates until complete.
+     */
+    suspend fun execute(interaction: ChatInputCommandInteraction) {
+        val command = interaction.command
+        val season = command.options["season"]!!.value.toString().toInt()
+        val week = command.options["week"]!!.value.toString().toInt()
+
+        Logger.info("${interaction.user.username} is starting all games for Season $season, Week $week")
+        val response = interaction.deferPublicResponse()
+
+        response.respond {
+            this.content = "Starting all games for Season $season, Week $week...\n" +
+                "This runs in the background with smart pacing. This message will update with progress."
+        }
+
+        try {
+            val result = gameClient.startWeek(season, week)
+            val jobId = result.keys.firstOrNull()
+            val error = result.values.firstOrNull()
+
+            if (jobId == null) {
+                response.respond {
+                    this.content = "FAILED: Could not start games for Season $season, Week $week: ${error ?: "Unknown error"}"
+                }
+                Logger.error("Failed to start games: $error")
+                return
+            }
+
+            Logger.info("Job $jobId created for Season $season, Week $week")
+
+            for (attempt in 1..MAX_POLL_ATTEMPTS) {
+                delay(POLL_INTERVAL_MS)
+
+                val status = gameClient.getGameWeekJobStatus(jobId) ?: continue
+
+                val jobStatus = status["status"] as? String ?: "UNKNOWN"
+                val totalGames = (status["totalGames"] as? Number)?.toInt() ?: 0
+                val startedGames = (status["startedGames"] as? Number)?.toInt() ?: 0
+                val failedGames = (status["failedGames"] as? Number)?.toInt() ?: 0
+                val currentIndex = (status["currentIndex"] as? Number)?.toInt() ?: 0
+
+                val progressBar = buildProgressBar(currentIndex, totalGames)
+
+                val message = buildString {
+                    appendLine("**Game Week Start -- Season $season, Week $week**")
+                    appendLine()
+                    appendLine(progressBar)
+                    appendLine()
+                    appendLine("**Progress:** $currentIndex / $totalGames games processed")
+                    appendLine("Started: $startedGames | Failed: $failedGames")
+
+                    if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
+                        appendLine()
+                        if (failedGames > 0) {
+                            appendLine("Completed with $failedGames failure(s). Use `/retry_week` or the website to retry failed games.")
+                            appendLine("Job ID: `$jobId`")
+                        } else {
+                            appendLine("All $startedGames games started successfully!")
+                        }
+                    }
+                }
+
+                response.respond {
+                    this.content = message
+                }
+
+                if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
+                    Logger.info("Job $jobId finished: $jobStatus (started=$startedGames, failed=$failedGames)")
+                    break
+                }
+            }
+        } catch (e: Exception) {
+            Logger.error("Error in start week command: ${e.message}")
+            response.respond {
+                this.content = "FAILED: Error starting week: ${e.message}"
+            }
+        }
+    }
+
+    private fun buildProgressBar(current: Int, total: Int): String {
+        if (total == 0) return "`[--------------------] 0%`"
+        val percent = (current.toDouble() / total * 100).toInt().coerceIn(0, 100)
+        val filled = (percent / 5).coerceIn(0, 20)
+        val empty = 20 - filled
+        return "`[${"#".repeat(filled)}${"-".repeat(empty)}] $percent%`"
+    }
+}

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
@@ -61,7 +61,6 @@ class StartWeekCommand(
             val pollingResult =
                 GameWeekPollingUtils.pollGameWeekJob(
                     gameClient = gameClient,
-                    interaction = interaction,
                     response = response,
                     config =
                         GameWeekPollingUtils.PollingConfig(
@@ -80,12 +79,12 @@ class StartWeekCommand(
                                     }
                                 }
                             },
-                            onTimeout = { jobId ->
-                                val timeoutMinutes = 720 * 5000L / 1000 / 60
-                                "**⚠️ Polling Timeout**\n\n" +
+                            onTimeout = { timeoutJobId ->
+                                val timeoutMinutes = GameWeekPollingUtils.getTimeoutMinutes()
+                                "**Polling Timeout**\n\n" +
                                     "Polling stopped after $timeoutMinutes minutes. " +
                                     "The job may still be running in the background.\n\n" +
-                                    "Job ID: `$jobId`\n" +
+                                    "Job ID: `$timeoutJobId`\n" +
                                     "Check the website or use `/retry_week` with this job ID to check status."
                             },
                         ),

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/game/StartWeekCommand.kt
@@ -1,22 +1,16 @@
 package com.fcfb.discord.refbot.commands.game
 
 import com.fcfb.discord.refbot.api.game.GameClient
-import com.fcfb.discord.refbot.utils.ProgressBarUtils
+import com.fcfb.discord.refbot.utils.polling.GameWeekPollingUtils
 import com.fcfb.discord.refbot.utils.system.Logger
 import dev.kord.core.Kord
 import dev.kord.core.behavior.interaction.response.respond
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction
 import dev.kord.rest.builder.interaction.integer
-import kotlinx.coroutines.delay
 
 class StartWeekCommand(
     private val gameClient: GameClient,
 ) {
-    companion object {
-        private const val POLL_INTERVAL_MS = 5000L
-        private const val MAX_POLL_ATTEMPTS = 720
-    }
-
     suspend fun register(client: Kord) {
         client.createGlobalChatInputCommand(
             "start_week",
@@ -50,9 +44,9 @@ class StartWeekCommand(
         }
 
         try {
-            val result = gameClient.startWeek(season, week)
-            val jobId = result.keys.firstOrNull()
-            val error = result.values.firstOrNull()
+            val startWeekResult = gameClient.startWeek(season, week)
+            val jobId = startWeekResult.keys.firstOrNull()
+            val error = startWeekResult.values.firstOrNull()
 
             if (jobId == null) {
                 response.respond {
@@ -64,65 +58,44 @@ class StartWeekCommand(
 
             Logger.info("Job $jobId created for Season $season, Week $week")
 
-            var jobCompleted = false
-            for (attempt in 1..MAX_POLL_ATTEMPTS) {
-                delay(POLL_INTERVAL_MS)
-
-                val status = gameClient.getGameWeekJobStatus(jobId) ?: continue
-
-                val jobStatus = status["status"] as? String ?: "UNKNOWN"
-                val totalGames = (status["totalGames"] as? Number)?.toInt() ?: 0
-                val startedGames = (status["startedGames"] as? Number)?.toInt() ?: 0
-                val failedGames = (status["failedGames"] as? Number)?.toInt() ?: 0
-                val currentIndex = (status["currentIndex"] as? Number)?.toInt() ?: 0
-
-                val progressBar = ProgressBarUtils.buildProgressBar(currentIndex, totalGames)
-
-                val message =
-                    buildString {
-                        appendLine("**Game Week Start -- Season $season, Week $week**")
-                        appendLine()
-                        appendLine(progressBar)
-                        appendLine()
-                        appendLine("**Progress:** $currentIndex / $totalGames games processed")
-                        appendLine("Started: $startedGames | Failed: $failedGames")
-
-                        if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
-                            appendLine()
-                            if (failedGames > 0) {
-                                appendLine(
-                                    "Completed with $failedGames failure(s). " +
-                                        "Use `/retry_week` or the website to retry failed games.",
-                                )
-                                appendLine("Job ID: `$jobId`")
-                            } else {
-                                appendLine("All $startedGames games started successfully!")
-                            }
-                        }
-                    }
-
-                response.respond {
-                    this.content = message
-                }
-
-                if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
-                    Logger.info("Job $jobId finished: $jobStatus (started=$startedGames, failed=$failedGames)")
-                    jobCompleted = true
-                    break
-                }
-            }
-
-            if (!jobCompleted) {
-                Logger.warn(
-                    "Polling timeout: Job $jobId did not complete within ${MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS / 1000 / 60} minutes",
+            val pollingResult =
+                GameWeekPollingUtils.pollGameWeekJob(
+                    gameClient = gameClient,
+                    interaction = interaction,
+                    response = response,
+                    config =
+                        GameWeekPollingUtils.PollingConfig(
+                            jobId = jobId,
+                            title = "Game Week Start -- Season $season, Week $week",
+                            onComplete = { pollingResult ->
+                                buildString {
+                                    if (pollingResult.failedGames > 0) {
+                                        appendLine(
+                                            "Completed with ${pollingResult.failedGames} failure(s). " +
+                                                "Use `/retry_week` or the website to retry failed games.",
+                                        )
+                                        appendLine("Job ID: `$jobId`")
+                                    } else {
+                                        appendLine("All ${pollingResult.startedGames} games started successfully!")
+                                    }
+                                }
+                            },
+                            onTimeout = { jobId ->
+                                val timeoutMinutes = 720 * 5000L / 1000 / 60
+                                "**⚠️ Polling Timeout**\n\n" +
+                                    "Polling stopped after $timeoutMinutes minutes. " +
+                                    "The job may still be running in the background.\n\n" +
+                                    "Job ID: `$jobId`\n" +
+                                    "Check the website or use `/retry_week` with this job ID to check status."
+                            },
+                        ),
                 )
-                response.respond {
-                    this.content = "**⚠️ Polling Timeout**\n\n" +
-                        "Polling stopped after ${MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS / 1000 / 60} minutes. " +
-                        "The job may still be running in the background.\n\n" +
-                        "Job ID: `$jobId`\n" +
-                        "Check the website or use `/retry_week` with this job ID to check status."
-                }
+
+            if (pollingResult.jobCompleted) {
+                Logger.info(
+                    "Job $jobId finished: ${pollingResult.finalStatus} " +
+                        "(started=${pollingResult.startedGames}, failed=${pollingResult.failedGames})",
+                )
             }
         } catch (e: Exception) {
             Logger.error("Error in start week command: ${e.message}")

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/infrastructure/CommandRegistry.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/infrastructure/CommandRegistry.kt
@@ -14,10 +14,12 @@ import com.fcfb.discord.refbot.commands.game.GameInfoCommand
 import com.fcfb.discord.refbot.commands.game.MessageAllGamesCommand
 import com.fcfb.discord.refbot.commands.game.PreviousPlayCommand
 import com.fcfb.discord.refbot.commands.game.RestartGameCommand
+import com.fcfb.discord.refbot.commands.game.RetryWeekCommand
 import com.fcfb.discord.refbot.commands.game.RollbackCommand
 import com.fcfb.discord.refbot.commands.game.ScoreChartCommand
 import com.fcfb.discord.refbot.commands.game.StartGameCommand
 import com.fcfb.discord.refbot.commands.game.StartScrimmageCommand
+import com.fcfb.discord.refbot.commands.game.StartWeekCommand
 import com.fcfb.discord.refbot.commands.game.WinProbabilityCommand
 import com.fcfb.discord.refbot.commands.system.HelpCommand
 import com.fcfb.discord.refbot.commands.user.GetRoleCommand
@@ -45,6 +47,8 @@ class CommandRegistry(
     private val pingCommand: PingCommand,
     private val startGameCommand: StartGameCommand,
     private val startScrimmageCommand: StartScrimmageCommand,
+    private val startWeekCommand: StartWeekCommand,
+    private val retryWeekCommand: RetryWeekCommand,
     private val subCoachCommand: SubCoachCommand,
     private val getRoleCommand: GetRoleCommand,
     private val rollbackCommand: RollbackCommand,
@@ -76,6 +80,8 @@ class CommandRegistry(
         scoreChartCommand.register(client)
         startGameCommand.register(client)
         startScrimmageCommand.register(client)
+        startWeekCommand.register(client)
+        retryWeekCommand.register(client)
         subCoachCommand.register(client)
         winProbabilityCommand.register(client)
     }
@@ -119,6 +125,8 @@ class CommandRegistry(
             "previous_play" -> previousPlayCommand.execute(interaction)
             "start_game" -> startGameCommand.execute(interaction)
             "start_scrimmage" -> startScrimmageCommand.execute(interaction)
+            "start_week" -> startWeekCommand.execute(interaction)
+            "retry_week" -> retryWeekCommand.execute(interaction)
             "sub_coach" -> subCoachCommand.execute(interaction)
             "get_role" -> getRoleCommand.execute(interaction)
             "rollback" -> rollbackCommand.execute(interaction)

--- a/src/main/kotlin/com/fcfb/discord/refbot/commands/infrastructure/Permissions.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/commands/infrastructure/Permissions.kt
@@ -18,6 +18,8 @@ object Permissions {
     private val adminCommands =
         setOf(
             "start_game",
+            "start_week",
+            "retry_week",
             "end_game",
             "end_all",
             "delete_game",

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -901,23 +901,7 @@ class DiscordMessageHandler(
         offensiveCoaches: List<User?>,
         defensiveCoaches: List<User?>,
     ): Pair<Pair<String, EmbedData?>, List<User?>> {
-        val title =
-            when {
-                game.gameType == GameType.BOWL && game.bowlGameName?.isNotBlank() == true -> {
-                    "${game.homeTeam} vs ${game.awayTeam} | ${game.bowlGameName}"
-                }
-                game.gameType == GameType.CONFERENCE_CHAMPIONSHIP -> {
-                    val conferenceName = gameUtils.getConferenceName(game.homeTeam)
-                    if (conferenceName != null) {
-                        "${game.homeTeam} vs ${game.awayTeam} | $conferenceName Championship"
-                    } else {
-                        "${game.homeTeam} vs ${game.awayTeam} | Conference Championship"
-                    }
-                }
-                else -> {
-                    "${game.homeTeam} vs ${game.awayTeam}"
-                }
-            }
+        val title = gameUtils.getGameEmbedTitle(game)
         val embedData =
             EmbedData(
                 title = Optional(title),
@@ -957,23 +941,7 @@ class DiscordMessageHandler(
                 append("**" + game.awayTeam).append(":** ").append(game.awayScore).append("\n")
                 append("----------------\n")
             }
-        val title =
-            when {
-                game.gameType == GameType.BOWL && game.bowlGameName?.isNotBlank() == true -> {
-                    "${game.homeTeam} vs ${game.awayTeam} | ${game.bowlGameName}"
-                }
-                game.gameType == GameType.CONFERENCE_CHAMPIONSHIP -> {
-                    val conferenceName = gameUtils.getConferenceName(game.homeTeam)
-                    if (conferenceName != null) {
-                        "${game.homeTeam} vs ${game.awayTeam} | $conferenceName Championship"
-                    } else {
-                        "${game.homeTeam} vs ${game.awayTeam} | Conference Championship"
-                    }
-                }
-                else -> {
-                    "${game.homeTeam} vs ${game.awayTeam}"
-                }
-            }
+        val title = gameUtils.getGameEmbedTitle(game)
         val embedData =
             EmbedData(
                 title = Optional(title),

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -904,9 +904,9 @@ class DiscordMessageHandler(
         val title = gameUtils.getGameEmbedTitle(game)
         val embedData =
             EmbedData(
-                title = Optional(title),
-                description = Optional(messageContent + ""),
-                footer = Optional(EmbedFooterData(text = gameUtils.getFormattedFooterText(game))),
+                title = Optional.Value(title),
+                description = Optional.Value(messageContent ?: ""),
+                footer = Optional.Value(EmbedFooterData(text = gameUtils.getFormattedFooterText(game))),
             )
 
         val messageToSend = appendUserPings(game, scenario, homeCoaches, awayCoaches, offensiveCoaches)
@@ -944,9 +944,9 @@ class DiscordMessageHandler(
         val title = gameUtils.getGameEmbedTitle(game)
         val embedData =
             EmbedData(
-                title = Optional(title),
-                description = Optional(messageContent + textScorebug),
-                footer = Optional(EmbedFooterData(text = gameUtils.getFormattedFooterText(game))),
+                title = Optional.Value(title),
+                description = Optional.Value(messageContent + textScorebug),
+                footer = Optional.Value(EmbedFooterData(text = gameUtils.getFormattedFooterText(game))),
             )
 
         val messageToSend = appendUserPings(game, scenario, homeCoaches, awayCoaches, offensiveCoaches)

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/DiscordMessageHandler.kt
@@ -901,9 +901,26 @@ class DiscordMessageHandler(
         offensiveCoaches: List<User?>,
         defensiveCoaches: List<User?>,
     ): Pair<Pair<String, EmbedData?>, List<User?>> {
+        val title =
+            when {
+                game.gameType == GameType.BOWL && game.bowlGameName?.isNotBlank() == true -> {
+                    "${game.homeTeam} vs ${game.awayTeam} | ${game.bowlGameName}"
+                }
+                game.gameType == GameType.CONFERENCE_CHAMPIONSHIP -> {
+                    val conferenceName = gameUtils.getConferenceName(game.homeTeam)
+                    if (conferenceName != null) {
+                        "${game.homeTeam} vs ${game.awayTeam} | $conferenceName Championship"
+                    } else {
+                        "${game.homeTeam} vs ${game.awayTeam} | Conference Championship"
+                    }
+                }
+                else -> {
+                    "${game.homeTeam} vs ${game.awayTeam}"
+                }
+            }
         val embedData =
             EmbedData(
-                title = Optional("${game.homeTeam} vs ${game.awayTeam}"),
+                title = Optional(title),
                 description = Optional(messageContent + ""),
                 footer = Optional(EmbedFooterData(text = gameUtils.getFormattedFooterText(game))),
             )
@@ -940,9 +957,26 @@ class DiscordMessageHandler(
                 append("**" + game.awayTeam).append(":** ").append(game.awayScore).append("\n")
                 append("----------------\n")
             }
+        val title =
+            when {
+                game.gameType == GameType.BOWL && game.bowlGameName?.isNotBlank() == true -> {
+                    "${game.homeTeam} vs ${game.awayTeam} | ${game.bowlGameName}"
+                }
+                game.gameType == GameType.CONFERENCE_CHAMPIONSHIP -> {
+                    val conferenceName = gameUtils.getConferenceName(game.homeTeam)
+                    if (conferenceName != null) {
+                        "${game.homeTeam} vs ${game.awayTeam} | $conferenceName Championship"
+                    } else {
+                        "${game.homeTeam} vs ${game.awayTeam} | Conference Championship"
+                    }
+                }
+                else -> {
+                    "${game.homeTeam} vs ${game.awayTeam}"
+                }
+            }
         val embedData =
             EmbedData(
-                title = Optional("${game.homeTeam} vs ${game.awayTeam}"),
+                title = Optional(title),
                 description = Optional(messageContent + textScorebug),
                 footer = Optional(EmbedFooterData(text = gameUtils.getFormattedFooterText(game))),
             )

--- a/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/TextChannelThreadHandler.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/handlers/discord/TextChannelThreadHandler.kt
@@ -263,7 +263,12 @@ class TextChannelThreadHandler(
                 return "PLAYOFFS || $teamMatchup"
             }
             GameType.BOWL -> {
-                return "BOWL || $teamMatchup"
+                val bowlName = game.bowlGameName?.takeIf { it.isNotBlank() }
+                return if (bowlName != null) {
+                    "BOWL | $teamMatchup | $bowlName"
+                } else {
+                    "BOWL || $teamMatchup"
+                }
             }
             GameType.CONFERENCE_CHAMPIONSHIP -> {
                 val apiResponse = teamClient.getTeamByName(game.homeTeam)
@@ -311,7 +316,12 @@ class TextChannelThreadHandler(
                 return "PLAYOFFS || $teamMatchup"
             }
             GameType.BOWL -> {
-                return "BOWL || $teamMatchup"
+                val bowlName = game.bowlGameName?.takeIf { it.isNotBlank() }
+                return if (bowlName != null) {
+                    "BOWL | $teamMatchup | $bowlName"
+                } else {
+                    "BOWL || $teamMatchup"
+                }
             }
             GameType.CONFERENCE_CHAMPIONSHIP -> {
                 val apiResponse = teamClient.getTeamByName(game.homeTeam)

--- a/src/main/kotlin/com/fcfb/discord/refbot/koin/AppModule.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/koin/AppModule.kt
@@ -23,10 +23,12 @@ import com.fcfb.discord.refbot.commands.game.GameInfoCommand
 import com.fcfb.discord.refbot.commands.game.MessageAllGamesCommand
 import com.fcfb.discord.refbot.commands.game.PreviousPlayCommand
 import com.fcfb.discord.refbot.commands.game.RestartGameCommand
+import com.fcfb.discord.refbot.commands.game.RetryWeekCommand
 import com.fcfb.discord.refbot.commands.game.RollbackCommand
 import com.fcfb.discord.refbot.commands.game.ScoreChartCommand
 import com.fcfb.discord.refbot.commands.game.StartGameCommand
 import com.fcfb.discord.refbot.commands.game.StartScrimmageCommand
+import com.fcfb.discord.refbot.commands.game.StartWeekCommand
 import com.fcfb.discord.refbot.commands.game.WinProbabilityCommand
 import com.fcfb.discord.refbot.commands.infrastructure.CommandRegistry
 import com.fcfb.discord.refbot.commands.system.HelpCommand
@@ -95,6 +97,8 @@ val appModule =
         single { PingCommand(get(), get(), get()) }
         single { StartGameCommand(get()) }
         single { StartScrimmageCommand(get()) }
+        single { StartWeekCommand(get()) }
+        single { RetryWeekCommand(get()) }
         single { SubCoachCommand(get(), get(), get()) }
         single { GetRoleCommand(get()) }
         single { GetTeamCoachesCommand(get()) }
@@ -105,7 +109,7 @@ val appModule =
         single {
             CommandRegistry(
                 get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
-                get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
+                get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
             )
         }
         single { FCFBDiscordRefBot(get(), get(), get(), get()) }

--- a/src/main/kotlin/com/fcfb/discord/refbot/model/domain/Game.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/model/domain/Game.kt
@@ -81,4 +81,6 @@ data class Game(
     @JsonProperty("upset_alert_pinged") val upsetAlertPinged: Boolean,
     @JsonProperty("home_vegas_spread") val homeVegasSpread: Double?,
     @JsonProperty("away_vegas_spread") val awayVegasSpread: Double?,
+    @JsonProperty("bowl_game_name") val bowlGameName: String?,
+    @JsonProperty("postseason_game_logo") val postseasonGameLogo: String?,
 )

--- a/src/main/kotlin/com/fcfb/discord/refbot/utils/ProgressBarUtils.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/utils/ProgressBarUtils.kt
@@ -1,0 +1,20 @@
+package com.fcfb.discord.refbot.utils
+
+object ProgressBarUtils {
+    /**
+     * Build a progress bar string for displaying job progress.
+     * @param current The current progress index
+     * @param total The total number of items
+     * @return A formatted progress bar string (e.g., "[####----] 50%")
+     */
+    fun buildProgressBar(
+        current: Int,
+        total: Int,
+    ): String {
+        if (total == 0) return "`[--------------------] 0%`"
+        val percent = (current.toDouble() / total * 100).toInt().coerceIn(0, 100)
+        val filled = (percent / 5).coerceIn(0, 20)
+        val empty = 20 - filled
+        return "`[${"#".repeat(filled)}${"-".repeat(empty)}] $percent%`"
+    }
+}

--- a/src/main/kotlin/com/fcfb/discord/refbot/utils/formatting/ProgressBarUtils.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/utils/formatting/ProgressBarUtils.kt
@@ -1,4 +1,4 @@
-package com.fcfb.discord.refbot.utils
+package com.fcfb.discord.refbot.utils.formatting
 
 object ProgressBarUtils {
     /**

--- a/src/main/kotlin/com/fcfb/discord/refbot/utils/game/GameUtils.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/utils/game/GameUtils.kt
@@ -578,23 +578,7 @@ class GameUtils(
                 file.path
             }
 
-        val title =
-            when {
-                game.gameType == GameType.BOWL && game.bowlGameName?.isNotBlank() == true -> {
-                    "${game.homeTeam} vs ${game.awayTeam} | ${game.bowlGameName}"
-                }
-                game.gameType == GameType.CONFERENCE_CHAMPIONSHIP -> {
-                    val conferenceName = getConferenceName(game.homeTeam)
-                    if (conferenceName != null) {
-                        "${game.homeTeam} vs ${game.awayTeam} | $conferenceName Championship"
-                    } else {
-                        "${game.homeTeam} vs ${game.awayTeam} | Conference Championship"
-                    }
-                }
-                else -> {
-                    "${game.homeTeam} vs ${game.awayTeam}"
-                }
-            }
+        val title = getGameEmbedTitle(game)
         return EmbedData(
             title = Optional(title),
             description = Optional(embedContent.orEmpty()),

--- a/src/main/kotlin/com/fcfb/discord/refbot/utils/game/GameUtils.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/utils/game/GameUtils.kt
@@ -544,6 +544,29 @@ class GameUtils(
     }
 
     /**
+     * Get the embed title for a game based on its type.
+     * Handles bowl games, conference championships, and regular games.
+     */
+    suspend fun getGameEmbedTitle(game: Game): String {
+        return when {
+            game.gameType == GameType.BOWL && game.bowlGameName?.isNotBlank() == true -> {
+                "${game.homeTeam} vs ${game.awayTeam} | ${game.bowlGameName}"
+            }
+            game.gameType == GameType.CONFERENCE_CHAMPIONSHIP -> {
+                val conferenceName = getConferenceName(game.homeTeam)
+                if (conferenceName != null) {
+                    "${game.homeTeam} vs ${game.awayTeam} | $conferenceName Championship"
+                } else {
+                    "${game.homeTeam} vs ${game.awayTeam} | Conference Championship"
+                }
+            }
+            else -> {
+                "${game.homeTeam} vs ${game.awayTeam}"
+            }
+        }
+    }
+
+    /**
      * Get the scorebug embed for a game
      * @param game The game object
      * @param embedContent The embed content
@@ -580,10 +603,10 @@ class GameUtils(
 
         val title = getGameEmbedTitle(game)
         return EmbedData(
-            title = Optional(title),
-            description = Optional(embedContent.orEmpty()),
-            image = Optional(EmbedImageData(url = Optional(scorebugUrl))),
-            footer = Optional(EmbedFooterData(text = getFormattedFooterText(game))),
+            title = Optional.Value(title),
+            description = Optional.Value(embedContent.orEmpty()),
+            image = Optional.Value(EmbedImageData(url = Optional.Value(scorebugUrl))),
+            footer = Optional.Value(EmbedFooterData(text = getFormattedFooterText(game))),
         )
     }
 
@@ -620,10 +643,10 @@ class GameUtils(
                 ?: return null
 
         return EmbedData(
-            title = Optional("Win Probability Chart - ${game.homeTeam} vs ${game.awayTeam}"),
-            description = Optional(embedContent.orEmpty()),
-            image = Optional(EmbedImageData(url = Optional(chartUrl))),
-            footer = Optional(EmbedFooterData(text = getFormattedFooterText(game))),
+            title = Optional.Value("Win Probability Chart - ${game.homeTeam} vs ${game.awayTeam}"),
+            description = Optional.Value(embedContent.orEmpty()),
+            image = Optional.Value(EmbedImageData(url = Optional.Value(chartUrl))),
+            footer = Optional.Value(EmbedFooterData(text = getFormattedFooterText(game))),
         )
     }
 
@@ -648,10 +671,10 @@ class GameUtils(
                 ?: return null
 
         return EmbedData(
-            title = Optional("Score Chart - ${game.homeTeam} vs ${game.awayTeam}"),
-            description = Optional(embedContent.orEmpty()),
-            image = Optional(EmbedImageData(url = Optional(chartUrl))),
-            footer = Optional(EmbedFooterData(text = getFormattedFooterText(game))),
+            title = Optional.Value("Score Chart - ${game.homeTeam} vs ${game.awayTeam}"),
+            description = Optional.Value(embedContent.orEmpty()),
+            image = Optional.Value(EmbedImageData(url = Optional.Value(chartUrl))),
+            footer = Optional.Value(EmbedFooterData(text = getFormattedFooterText(game))),
         )
     }
 

--- a/src/main/kotlin/com/fcfb/discord/refbot/utils/polling/GameWeekPollingUtils.kt
+++ b/src/main/kotlin/com/fcfb/discord/refbot/utils/polling/GameWeekPollingUtils.kt
@@ -1,0 +1,148 @@
+package com.fcfb.discord.refbot.utils.polling
+
+import com.fcfb.discord.refbot.api.game.GameClient
+import com.fcfb.discord.refbot.utils.formatting.ProgressBarUtils
+import com.fcfb.discord.refbot.utils.system.Logger
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.behavior.interaction.response.respond
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import kotlinx.coroutines.delay
+
+object GameWeekPollingUtils {
+    private const val POLL_INTERVAL_MS = 5000L
+    private const val MAX_POLL_ATTEMPTS = 720
+    private const val DISCORD_TOKEN_LIFETIME_MS = 15 * 60 * 1000L // 15 minutes
+
+    data class PollingResult(
+        val jobCompleted: Boolean,
+        val finalStatus: String?,
+        val totalGames: Int,
+        val startedGames: Int,
+        val failedGames: Int,
+        val currentIndex: Int,
+    )
+
+    data class PollingConfig(
+        val jobId: String,
+        val title: String,
+        val onComplete: (PollingResult) -> String,
+        val onTimeout: (String) -> String,
+    )
+
+    /**
+     * Poll for game week job status with automatic handling of Discord token expiration.
+     * After 15 minutes, Discord interaction tokens expire, so updates will stop being sent.
+     * Polling continues in the background and logs are still generated.
+     */
+    suspend fun pollGameWeekJob(
+        gameClient: GameClient,
+        interaction: ChatInputCommandInteraction,
+        response: DeferredPublicMessageInteractionResponseBehavior,
+        config: PollingConfig,
+    ): PollingResult {
+        val startTime = System.currentTimeMillis()
+        var tokenExpired = false
+
+        var jobCompleted = false
+        var finalStatus: String? = null
+        var totalGames = 0
+        var startedGames = 0
+        var failedGames = 0
+        var currentIndex = 0
+
+        for (attempt in 1..MAX_POLL_ATTEMPTS) {
+            delay(POLL_INTERVAL_MS)
+
+            val status = gameClient.getGameWeekJobStatus(config.jobId) ?: continue
+
+            val jobStatus = status["status"] as? String ?: "UNKNOWN"
+            totalGames = (status["totalGames"] as? Number)?.toInt() ?: 0
+            startedGames = (status["startedGames"] as? Number)?.toInt() ?: 0
+            failedGames = (status["failedGames"] as? Number)?.toInt() ?: 0
+            currentIndex = (status["currentIndex"] as? Number)?.toInt() ?: 0
+
+            val progressBar = ProgressBarUtils.buildProgressBar(currentIndex, totalGames)
+
+            val message =
+                buildString {
+                    appendLine("**${config.title}**")
+                    appendLine()
+                    appendLine(progressBar)
+                    appendLine()
+                    appendLine("**Progress:** $currentIndex / $totalGames games processed")
+                    appendLine("Started: $startedGames | Failed: $failedGames")
+
+                    if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
+                        appendLine()
+                        appendLine(config.onComplete(PollingResult(true, jobStatus, totalGames, startedGames, failedGames, currentIndex)))
+                    }
+                }
+
+            // Check if token has expired (15 minutes)
+            val elapsed = System.currentTimeMillis() - startTime
+            if (!tokenExpired && elapsed >= DISCORD_TOKEN_LIFETIME_MS) {
+                Logger.warn(
+                    "Discord interaction token expired after 15 minutes for job ${config.jobId}. Updates will stop, but polling continues.",
+                )
+                tokenExpired = true
+            }
+
+            // Only try to send updates if token hasn't expired
+            if (!tokenExpired) {
+                try {
+                    response.respond {
+                        this.content = message
+                    }
+                } catch (e: Exception) {
+                    // Check if this is a token expiration error
+                    val isTokenError =
+                        e.message?.contains("token", ignoreCase = true) == true ||
+                            e.message?.contains("webhook", ignoreCase = true) == true ||
+                            e.message?.contains("expired", ignoreCase = true) == true ||
+                            e.message?.contains("401", ignoreCase = false) == true ||
+                            e.message?.contains("Unauthorized", ignoreCase = true) == true
+
+                    if (isTokenError) {
+                        Logger.warn(
+                            "Discord interaction token expired. Updates stopped for job ${config.jobId}. Polling continues in background.",
+                        )
+                        tokenExpired = true
+                    } else {
+                        Logger.error("Failed to send polling update: ${e.message}")
+                        // Continue polling but stop sending updates on non-token errors too
+                        tokenExpired = true
+                    }
+                }
+            }
+
+            if (jobStatus == "COMPLETED" || jobStatus == "FAILED") {
+                finalStatus = jobStatus
+                jobCompleted = true
+                break
+            }
+        }
+
+        // Send timeout message if job didn't complete (only if token hasn't expired)
+        if (!jobCompleted && !tokenExpired) {
+            val timeoutMinutes = MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS / 1000 / 60
+            Logger.warn("Polling timeout: Job ${config.jobId} did not complete within $timeoutMinutes minutes")
+            val timeoutMessage = config.onTimeout(config.jobId)
+
+            try {
+                response.respond {
+                    this.content = timeoutMessage
+                }
+            } catch (e: Exception) {
+                Logger.error("Failed to send timeout message (token may have expired): ${e.message}")
+            }
+        } else if (!jobCompleted) {
+            // Log timeout even if we can't send a message
+            val timeoutMinutes = MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS / 1000 / 60
+            Logger.warn(
+                "Polling timeout: Job ${config.jobId} did not complete within $timeoutMinutes minutes (token expired, message not sent)",
+            )
+        }
+
+        return PollingResult(jobCompleted, finalStatus, totalGames, startedGames, failedGames, currentIndex)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new admin-only Discord commands that trigger asynchronous backend jobs and poll status; failures or API/Discord token expiry could lead to confusing or incomplete status updates for operators.
> 
> **Overview**
> Enables admins to start all games for a given season/week asynchronously via new `/start_week` and to retry failures via `/retry_week`, backed by new `GameClient` endpoints for starting a week, polling job status, and retrying failed games.
> 
> Adds reusable polling/progress rendering (`GameWeekPollingUtils`, `ProgressBarUtils`) that posts periodic progress updates and gracefully stops Discord updates when interaction tokens expire.
> 
> Improves postseason presentation by extending `Game` with bowl metadata, including bowl names in thread titles, and standardizing embed titles/`Optional.Value` usage (including conference championship titles fetched via `TeamClient`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1af17681c1e087a8bb84852ed1f8ccf72dc206c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->